### PR TITLE
feat: add license management api

### DIFF
--- a/backend/src/main/java/com/example/backend/controller/LicenseController.java
+++ b/backend/src/main/java/com/example/backend/controller/LicenseController.java
@@ -1,0 +1,86 @@
+package com.example.backend.controller;
+
+import com.example.backend.domain.ApiResponse;
+import com.example.backend.domain.License;
+import com.example.backend.service.LicenseService;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/licenses")
+@Validated
+public class LicenseController {
+    private final LicenseService licenseService;
+
+    public LicenseController(LicenseService licenseService) {
+        this.licenseService = licenseService;
+    }
+
+    public static class LicenseRequest {
+        @NotBlank
+        private String name;
+        private String badge;
+        @NotBlank
+        private String printSize;
+        @NotBlank
+        private String pixelSize;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getBadge() {
+            return badge;
+        }
+
+        public void setBadge(String badge) {
+            this.badge = badge;
+        }
+
+        public String getPrintSize() {
+            return printSize;
+        }
+
+        public void setPrintSize(String printSize) {
+            this.printSize = printSize;
+        }
+
+        public String getPixelSize() {
+            return pixelSize;
+        }
+
+        public void setPixelSize(String pixelSize) {
+            this.pixelSize = pixelSize;
+        }
+    }
+
+    @GetMapping
+    public ApiResponse<List<License>> list() {
+        return ApiResponse.success(licenseService.listAll());
+    }
+
+    @PostMapping
+    public ApiResponse<License> create(@RequestBody @Validated LicenseRequest req) {
+        License license = new License(null, req.getName(), req.getBadge(), req.getPrintSize(), req.getPixelSize());
+        return ApiResponse.success(licenseService.create(license));
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<License> update(@PathVariable Long id, @RequestBody @Validated LicenseRequest req) {
+        License license = new License(id, req.getName(), req.getBadge(), req.getPrintSize(), req.getPixelSize());
+        return ApiResponse.success(licenseService.update(license));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(@PathVariable Long id) {
+        licenseService.delete(id);
+        return ApiResponse.success(null);
+    }
+}

--- a/backend/src/main/java/com/example/backend/domain/License.java
+++ b/backend/src/main/java/com/example/backend/domain/License.java
@@ -1,0 +1,59 @@
+package com.example.backend.domain;
+
+public class License {
+    private Long id;
+    private String name;
+    private String badge;
+    private String printSize;
+    private String pixelSize;
+
+    public License() {}
+
+    public License(Long id, String name, String badge, String printSize, String pixelSize) {
+        this.id = id;
+        this.name = name;
+        this.badge = badge;
+        this.printSize = printSize;
+        this.pixelSize = pixelSize;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getBadge() {
+        return badge;
+    }
+
+    public void setBadge(String badge) {
+        this.badge = badge;
+    }
+
+    public String getPrintSize() {
+        return printSize;
+    }
+
+    public void setPrintSize(String printSize) {
+        this.printSize = printSize;
+    }
+
+    public String getPixelSize() {
+        return pixelSize;
+    }
+
+    public void setPixelSize(String pixelSize) {
+        this.pixelSize = pixelSize;
+    }
+}

--- a/backend/src/main/java/com/example/backend/repository/InMemoryLicenseRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/InMemoryLicenseRepository.java
@@ -1,0 +1,47 @@
+package com.example.backend.repository;
+
+import com.example.backend.domain.License;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class InMemoryLicenseRepository implements LicenseRepository {
+    private final Map<Long, License> store = new ConcurrentHashMap<>();
+    private final AtomicLong idGen = new AtomicLong(0);
+
+    @PostConstruct
+    public void init() {
+        save(new License(null, "身份证", "含回执", "26x32mm", "358x441px"));
+    }
+
+    @Override
+    public List<License> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    @Override
+    public License findById(Long id) {
+        return store.get(id);
+    }
+
+    @Override
+    public License save(License license) {
+        if (license.getId() == null) {
+            long id = idGen.incrementAndGet();
+            license.setId(id);
+        }
+        store.put(license.getId(), license);
+        return license;
+    }
+
+    @Override
+    public void delete(Long id) {
+        store.remove(id);
+    }
+}

--- a/backend/src/main/java/com/example/backend/repository/LicenseRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/LicenseRepository.java
@@ -1,0 +1,12 @@
+package com.example.backend.repository;
+
+import com.example.backend.domain.License;
+
+import java.util.List;
+
+public interface LicenseRepository {
+    List<License> findAll();
+    License findById(Long id);
+    License save(License license);
+    void delete(Long id);
+}

--- a/backend/src/main/java/com/example/backend/service/LicenseService.java
+++ b/backend/src/main/java/com/example/backend/service/LicenseService.java
@@ -1,0 +1,39 @@
+package com.example.backend.service;
+
+import com.example.backend.domain.License;
+import com.example.backend.exception.BusinessException;
+import com.example.backend.repository.LicenseRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class LicenseService {
+    private final LicenseRepository licenseRepository;
+
+    public LicenseService(LicenseRepository licenseRepository) {
+        this.licenseRepository = licenseRepository;
+    }
+
+    public List<License> listAll() {
+        return licenseRepository.findAll();
+    }
+
+    public License create(License license) {
+        return licenseRepository.save(license);
+    }
+
+    public License update(License license) {
+        if (licenseRepository.findById(license.getId()) == null) {
+            throw new BusinessException(20001, "license not found");
+        }
+        return licenseRepository.save(license);
+    }
+
+    public void delete(Long id) {
+        if (licenseRepository.findById(id) == null) {
+            throw new BusinessException(20001, "license not found");
+        }
+        licenseRepository.delete(id);
+    }
+}

--- a/backend/update.sql
+++ b/backend/update.sql
@@ -1,4 +1,6 @@
+DROP TABLE IF EXISTS licenses;
 DROP TABLE IF EXISTS users;
+
 CREATE TABLE users (
   id BIGINT PRIMARY KEY AUTO_INCREMENT,
   username VARCHAR(50) NOT NULL UNIQUE,
@@ -9,4 +11,20 @@ INSERT INTO users(id, username, password_hash) VALUES (
   1,
   'admin',
   '240be518fabd2724ddb6f04eeb1da5967448d7e831c08c8fa822809f74c720a9'
+);
+
+CREATE TABLE licenses (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(100) NOT NULL,
+  badge VARCHAR(50),
+  print_size VARCHAR(20) NOT NULL,
+  pixel_size VARCHAR(20) NOT NULL
+);
+
+INSERT INTO licenses(id, name, badge, print_size, pixel_size) VALUES (
+  1,
+  '身份证',
+  '含回执',
+  '26x32mm',
+  '358x441px'
 );


### PR DESCRIPTION
## Summary
- add License domain, repository, service, and controller for CRUD APIs
- include in-memory storage with sample entry
- extend update.sql with licenses table and seed data

## Testing
- `mvn -q -e test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c3c7e0da483259f6694a18245b451