### PR TITLE
feat: add certificate management

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/controller/v1/CertificateController.java
+++ b/backend/src/main/java/io/github/talelin/latticy/controller/v1/CertificateController.java
@@ -1,0 +1,64 @@
+package io.github.talelin.latticy.controller.v1;
+
+import io.github.talelin.autoconfigure.exception.NotFoundException;
+import io.github.talelin.latticy.dto.CertificateDTO;
+import io.github.talelin.latticy.model.CertificateDO;
+import io.github.talelin.latticy.service.CertificateService;
+import io.github.talelin.latticy.vo.CreatedVO;
+import io.github.talelin.latticy.vo.DeletedVO;
+import io.github.talelin.latticy.vo.UpdatedVO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.constraints.Positive;
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/certificate")
+@Validated
+public class CertificateController {
+
+    @Autowired
+    private CertificateService certificateService;
+
+    @GetMapping("/{id}")
+    public CertificateDO get(@PathVariable("id") @Positive Integer id) {
+        CertificateDO certificate = certificateService.getById(id);
+        if (certificate == null) {
+            throw new NotFoundException("certificate not found", 10022);
+        }
+        return certificate;
+    }
+
+    @GetMapping("")
+    public List<CertificateDO> getAll() {
+        return certificateService.findAll();
+    }
+
+    @PostMapping("")
+    public CreatedVO create(@RequestBody @Validated CertificateDTO dto) {
+        certificateService.create(dto);
+        return new CreatedVO();
+    }
+
+    @PutMapping("/{id}")
+    public UpdatedVO update(@PathVariable("id") @Positive Integer id, @RequestBody @Validated CertificateDTO dto) {
+        CertificateDO certificate = certificateService.getById(id);
+        if (certificate == null) {
+            throw new NotFoundException("certificate not found", 10022);
+        }
+        certificateService.update(certificate, dto);
+        return new UpdatedVO();
+    }
+
+    @DeleteMapping("/{id}")
+    public DeletedVO delete(@PathVariable("id") @Positive Integer id) {
+        CertificateDO certificate = certificateService.getById(id);
+        if (certificate == null) {
+            throw new NotFoundException("certificate not found", 10022);
+        }
+        certificateService.deleteById(id);
+        return new DeletedVO();
+    }
+}

--- a/backend/src/main/java/io/github/talelin/latticy/dto/CertificateDTO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/dto/CertificateDTO.java
@@ -1,0 +1,22 @@
+package io.github.talelin.latticy.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+public class CertificateDTO {
+    @NotBlank
+    private String name;
+    private String badge;
+    private Boolean hasReceipt;
+    private String printSize;
+    private String pixelSize;
+    private String resolution;
+    private Boolean saveElectronicPhoto;
+    private Boolean printLayout;
+    private String bgColor;
+    private String imageFormat;
+    private String imageFileSize;
+    private String requirements;
+}

--- a/backend/src/main/java/io/github/talelin/latticy/mapper/CertificateMapper.java
+++ b/backend/src/main/java/io/github/talelin/latticy/mapper/CertificateMapper.java
@@ -1,0 +1,9 @@
+package io.github.talelin.latticy.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import io.github.talelin.latticy.model.CertificateDO;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CertificateMapper extends BaseMapper<CertificateDO> {
+}

--- a/backend/src/main/java/io/github/talelin/latticy/model/CertificateDO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/model/CertificateDO.java
@@ -1,0 +1,27 @@
+package io.github.talelin.latticy.model;
+
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+
+@Data
+@TableName("certificate")
+@EqualsAndHashCode(callSuper = true)
+public class CertificateDO extends BaseModel implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String name;
+    private String badge;
+    private Boolean hasReceipt;
+    private String printSize;
+    private String pixelSize;
+    private String resolution;
+    private Boolean saveElectronicPhoto;
+    private Boolean printLayout;
+    private String bgColor;
+    private String imageFormat;
+    private String imageFileSize;
+    private String requirements;
+}

--- a/backend/src/main/java/io/github/talelin/latticy/service/CertificateService.java
+++ b/backend/src/main/java/io/github/talelin/latticy/service/CertificateService.java
@@ -1,0 +1,14 @@
+package io.github.talelin.latticy.service;
+
+import io.github.talelin.latticy.dto.CertificateDTO;
+import io.github.talelin.latticy.model.CertificateDO;
+
+import java.util.List;
+
+public interface CertificateService {
+    boolean create(CertificateDTO dto);
+    boolean update(CertificateDO certificate, CertificateDTO dto);
+    CertificateDO getById(Integer id);
+    List<CertificateDO> findAll();
+    boolean deleteById(Integer id);
+}

--- a/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
+++ b/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
@@ -1,0 +1,60 @@
+package io.github.talelin.latticy.service.impl;
+
+import io.github.talelin.latticy.dto.CertificateDTO;
+import io.github.talelin.latticy.mapper.CertificateMapper;
+import io.github.talelin.latticy.model.CertificateDO;
+import io.github.talelin.latticy.service.CertificateService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CertificateServiceImpl implements CertificateService {
+
+    @Autowired
+    private CertificateMapper certificateMapper;
+
+    @Override
+    public boolean create(CertificateDTO dto) {
+        CertificateDO cert = new CertificateDO();
+        copyFields(cert, dto);
+        return certificateMapper.insert(cert) > 0;
+    }
+
+    @Override
+    public boolean update(CertificateDO certificate, CertificateDTO dto) {
+        copyFields(certificate, dto);
+        return certificateMapper.updateById(certificate) > 0;
+    }
+
+    @Override
+    public CertificateDO getById(Integer id) {
+        return certificateMapper.selectById(id);
+    }
+
+    @Override
+    public List<CertificateDO> findAll() {
+        return certificateMapper.selectList(null);
+    }
+
+    @Override
+    public boolean deleteById(Integer id) {
+        return certificateMapper.deleteById(id) > 0;
+    }
+
+    private void copyFields(CertificateDO target, CertificateDTO dto) {
+        target.setName(dto.getName());
+        target.setBadge(dto.getBadge());
+        target.setHasReceipt(dto.getHasReceipt());
+        target.setPrintSize(dto.getPrintSize());
+        target.setPixelSize(dto.getPixelSize());
+        target.setResolution(dto.getResolution());
+        target.setSaveElectronicPhoto(dto.getSaveElectronicPhoto());
+        target.setPrintLayout(dto.getPrintLayout());
+        target.setBgColor(dto.getBgColor());
+        target.setImageFormat(dto.getImageFormat());
+        target.setImageFileSize(dto.getImageFileSize());
+        target.setRequirements(dto.getRequirements());
+    }
+}

--- a/backend/update.sql
+++ b/backend/update.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS certificate;
+CREATE TABLE certificate (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(50) NOT NULL,
+  badge VARCHAR(50),
+  has_receipt TINYINT(1) DEFAULT 0,
+  print_size VARCHAR(20),
+  pixel_size VARCHAR(20),
+  resolution VARCHAR(20),
+  save_electronic_photo TINYINT(1),
+  print_layout TINYINT(1),
+  bg_color VARCHAR(20),
+  image_format VARCHAR(20),
+  image_file_size VARCHAR(50),
+  requirements VARCHAR(255),
+  create_time DATETIME,
+  update_time DATETIME,
+  delete_time DATETIME
+);

--- a/cms-vue/src/config/stage/certificate.js
+++ b/cms-vue/src/config/stage/certificate.js
@@ -1,0 +1,23 @@
+const certificateRouter = {
+  route: null,
+  name: null,
+  title: '证照管理',
+  type: 'folder',
+  icon: 'iconfont icon-tushuguanli',
+  filePath: 'view/certificate/',
+  order: null,
+  inNav: true,
+  children: [
+    {
+      title: '证照列表',
+      type: 'view',
+      name: 'CertificateList',
+      route: '/certificate/list',
+      filePath: 'view/certificate/certificate-list.vue',
+      inNav: true,
+      icon: 'iconfont icon-tushuguanli',
+    },
+  ],
+}
+
+export default certificateRouter

--- a/cms-vue/src/config/stage/index.js
+++ b/cms-vue/src/config/stage/index.js
@@ -1,17 +1,6 @@
 import Utils from '@/lin/util/util'
 import adminConfig from './admin'
-import staticsConfig from './statics'
-import bannerConfig from './banner'
-import categoryConfig from './category'
-import gridCategoryConfig from './grid-categroy'
-import specConfig from './spec'
-import spuConfig from './spu'
-import skuConfig from './sku'
-import themeConfig from './theme'
-import activityConfig from './activity'
-import bookConfig from './book' // 引入图书管理路由文件
-import merchantConfig from './merchant'
-import pluginsConfig from './plugin'
+import certificateConfig from './certificate'
 
 // eslint-disable-next-line import/no-mutable-exports
 let homeRouter = [
@@ -54,47 +43,9 @@ let homeRouter = [
     inNav: false,
     icon: 'iconfont icon-rizhiguanli',
   },
-  staticsConfig,
-  bannerConfig,
-  categoryConfig,
-  gridCategoryConfig,
-  specConfig,
-  merchantConfig,
-  spuConfig,
-  skuConfig,
-  themeConfig,
-  activityConfig,
-  // bookConfig,
+  certificateConfig,
   adminConfig,
 ]
-
-const plugins = [
-  ...pluginsConfig
-]
-
-// 筛除已经被添加的插件
-function filterPlugin(data) {
-  if (plugins.length === 0) {
-    return
-  }
-  if (Array.isArray(data)) {
-    data.forEach(item => {
-      filterPlugin(item)
-    })
-  } else {
-    const findResult = plugins.findIndex(item => data === item)
-    if (findResult >= 0) {
-      plugins.splice(findResult, 1)
-    }
-    if (data.children) {
-      filterPlugin(data.children)
-    }
-  }
-}
-
-filterPlugin(homeRouter)
-
-homeRouter = homeRouter.concat(plugins)
 
 // 处理顺序
 homeRouter = Utils.sortByOrder(homeRouter)

--- a/cms-vue/src/model/certificate.js
+++ b/cms-vue/src/model/certificate.js
@@ -1,0 +1,37 @@
+/* eslint-disable class-methods-use-this */
+import _axios, { get, put, _delete } from '@/lin/plugin/axios'
+
+class Certificate {
+  async createCertificate(data) {
+    return _axios({
+      method: 'post',
+      url: 'v1/certificate',
+      data,
+    })
+  }
+
+  async getCertificate(id) {
+    const res = await get(`v1/certificate/${id}`)
+    return res
+  }
+
+  async editCertificate(id, info) {
+    const res = await put(`v1/certificate/${id}`, info)
+    return res
+  }
+
+  async deleteCertificate(id) {
+    const res = await _delete(`v1/certificate/${id}`)
+    return res
+  }
+
+  async getCertificates() {
+    return _axios({
+      method: 'get',
+      url: 'v1/certificate',
+      handleError: true,
+    })
+  }
+}
+
+export default new Certificate()

--- a/cms-vue/src/view/certificate/certificate-list.vue
+++ b/cms-vue/src/view/certificate/certificate-list.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="container">
+    <div class="header"><div class="title">证照列表</div></div>
+    <lin-table
+      :tableColumn="tableColumn"
+      :tableData="tableData"
+      v-loading="loading"
+    ></lin-table>
+  </div>
+</template>
+
+<script>
+import certificate from '@/model/certificate'
+import LinTable from '@/component/base/table/lin-table'
+
+export default {
+  components: {
+    LinTable,
+  },
+  data() {
+    return {
+      tableColumn: [
+        { prop: 'name', label: '名称' },
+        { prop: 'badge', label: '类型' },
+        { prop: 'hasReceipt', label: '含回执' },
+      ],
+      tableData: [],
+      loading: false,
+    }
+  },
+  async created() {
+    this.loading = true
+    await this.getCertificates()
+    this.loading = false
+  },
+  methods: {
+    async getCertificates() {
+      try {
+        const list = await certificate.getCertificates()
+        this.tableData = list
+      } catch (error) {
+        this.tableData = []
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.container {
+  padding: 0 30px;
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    .title {
+      height: 59px;
+      line-height: 59px;
+      color: $parent-title-color;
+      font-size: 16px;
+      font-weight: 500;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- add certificate table and CRUD API
- simplify CMS navigation and add certificate list page

## Testing
- `mvn -q -e test` (fails: Network is unreachable)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689c4b98c5388325b7afe1b6abbbf7b9