### PR TITLE
feat: remove badge field

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/dto/CertificateDTO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/dto/CertificateDTO.java
@@ -9,7 +9,6 @@ import java.math.BigDecimal;
 public class CertificateDTO {
     @NotBlank
     private String name;
-    private String badge;
     private Boolean hasReceipt;
     private String printSize;
     private String pixelSize;

--- a/backend/src/main/java/io/github/talelin/latticy/model/CertificateDO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/model/CertificateDO.java
@@ -14,7 +14,6 @@ public class CertificateDO extends BaseModel implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String name;
-    private String badge;
     private Boolean hasReceipt;
     private String printSize;
     private String pixelSize;

--- a/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
+++ b/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
@@ -45,7 +45,6 @@ public class CertificateServiceImpl implements CertificateService {
 
     private void copyFields(CertificateDO target, CertificateDTO dto) {
         target.setName(dto.getName());
-        target.setBadge(dto.getBadge());
         target.setHasReceipt(dto.getHasReceipt());
         target.setPrintSize(dto.getPrintSize());
         target.setPixelSize(dto.getPixelSize());

--- a/backend/update.sql
+++ b/backend/update.sql
@@ -2,7 +2,6 @@ DROP TABLE IF EXISTS certificate;
 CREATE TABLE certificate (
   id INT AUTO_INCREMENT PRIMARY KEY,
   name VARCHAR(50) NOT NULL,
-  badge VARCHAR(50),
   has_receipt TINYINT(1) DEFAULT 0,
   print_size VARCHAR(20),
   pixel_size VARCHAR(20),

--- a/cms-vue/src/view/certificate/certificate-create.vue
+++ b/cms-vue/src/view/certificate/certificate-create.vue
@@ -11,9 +11,6 @@
             <el-form-item label="名称" prop="name">
               <el-input v-model="form.name" placeholder="请输入名称" />
             </el-form-item>
-            <el-form-item label="类型" prop="badge">
-              <el-input v-model="form.badge" placeholder="请输入类型" />
-            </el-form-item>
             <el-form-item label="含回执" prop="hasReceipt">
               <el-switch v-model="form.hasReceipt" />
             </el-form-item>
@@ -36,7 +33,7 @@
               <el-switch v-model="form.printLayout" />
             </el-form-item>
             <el-form-item label="背景色" prop="bgColor">
-              <el-input v-model="form.bgColor" placeholder="例：#FFFFFF" />
+              <el-color-picker v-model="form.bgColor" />
             </el-form-item>
             <el-form-item label="图片格式" prop="imageFormat">
               <el-input v-model="form.imageFormat" placeholder="例：JPEG" />
@@ -65,7 +62,6 @@ export default {
     return {
       form: {
         name: '',
-        badge: '',
         hasReceipt: false,
         price: 0,
         printSize: '',

--- a/cms-vue/src/view/certificate/certificate-list.vue
+++ b/cms-vue/src/view/certificate/certificate-list.vue
@@ -24,7 +24,6 @@ export default {
     return {
       tableColumn: [
         { prop: 'name', label: '名称' },
-        { prop: 'badge', label: '类型' },
         { prop: 'hasReceipt', label: '含回执' },
         { prop: 'price', label: '价格' },
         { prop: 'printSize', label: '打印尺寸' },

--- a/miniapp/zfb-uniapp/pages/main/components/home-content.vue
+++ b/miniapp/zfb-uniapp/pages/main/components/home-content.vue
@@ -71,8 +71,8 @@
             </view>
             <view class="doc-info">
               <view class="doc-header">
-                <text class="doc-name">{{ document.name }}</text>
-                <text class="doc-badge">{{ document.badge }}</text>
+                  <text class="doc-name">{{ document.name }}</text>
+                  <text class="doc-badge" v-if="document.hasReceipt">含回执</text>
               </view>
               <view class="doc-specs">
                 <text class="spec-tag">可冲印</text>
@@ -120,7 +120,6 @@ export default {
           {
             id: 1,
             name: '身份证',
-            badge: '含回执',
             hasReceipt: true,
             price: 20,
             specs: {
@@ -138,7 +137,6 @@ export default {
           {
             id: 2,
             name: '港澳通行证',
-            badge: '含回执',
             hasReceipt: true,
             price: 20,
             specs: {
@@ -156,7 +154,6 @@ export default {
           {
             id: 3,
             name: '社保证',
-            badge: '含回执',
             hasReceipt: true,
             price: 20,
             specs: {
@@ -174,7 +171,6 @@ export default {
           {
             id: 4,
             name: '护照',
-            badge: '含回执',
             hasReceipt: true,
             price: 20,
             specs: {
@@ -194,7 +190,6 @@ export default {
           {
             id: 5,
             name: '驾驶证',
-            badge: '标准证照',
             hasReceipt: false,
             price: 20,
             specs: {
@@ -212,7 +207,6 @@ export default {
           {
             id: 6,
             name: '工作证',
-            badge: '标准证照',
             hasReceipt: false,
             price: 20,
             specs: {
@@ -230,7 +224,6 @@ export default {
           {
             id: 7,
             name: '学生证',
-            badge: '标准证照',
             hasReceipt: false,
             price: 20,
             specs: {
@@ -250,7 +243,6 @@ export default {
           {
             id: 8,
             name: '美国签证',
-            badge: '签证专用',
             hasReceipt: false,
             price: 20,
             specs: {
@@ -268,7 +260,6 @@ export default {
           {
             id: 9,
             name: '日本签证',
-            badge: '签证专用',
             hasReceipt: false,
             price: 20,
             specs: {
@@ -286,7 +277,6 @@ export default {
           {
             id: 10,
             name: '韩国签证',
-            badge: '签证专用',
             hasReceipt: false,
             price: 20,
             specs: {
@@ -306,7 +296,6 @@ export default {
           {
             id: 11,
             name: '公务员考试',
-            badge: '考试专用',
             hasReceipt: false,
             price: 20,
             specs: {
@@ -324,7 +313,6 @@ export default {
           {
             id: 12,
             name: '教师资格证',
-            badge: '考试专用',
             hasReceipt: false,
             price: 20,
             specs: {
@@ -342,7 +330,6 @@ export default {
           {
             id: 13,
             name: '会计师考试',
-            badge: '考试专用',
             hasReceipt: false,
             price: 20,
             specs: {
@@ -362,7 +349,6 @@ export default {
           {
             id: 14,
             name: '身份证',
-            badge: '最近使用',
             hasReceipt: true,
             price: 20,
             specs: {
@@ -380,7 +366,6 @@ export default {
           {
             id: 15,
             name: '护照',
-            badge: '最近使用',
             hasReceipt: true,
             price: 20,
             specs: {

--- a/miniapp/zfb-uniapp/pages/search/search.vue
+++ b/miniapp/zfb-uniapp/pages/search/search.vue
@@ -68,8 +68,8 @@
                     </view>
                     <view class="doc-info">
                         <view class="doc-header">
-                            <text class="doc-name">{{ item.name }}</text>
-                            <text class="doc-badge">{{ item.badge }}</text>
+                              <text class="doc-name">{{ item.name }}</text>
+                              <text class="doc-badge" v-if="item.hasReceipt">含回执</text>
                         </view>
                         <view class="doc-specs">
                             <text class="spec-tag">可冲印</text>
@@ -98,7 +98,6 @@ export default {
                 {
                     id: 1,
                     name: '身份证',
-                    badge: '含回执',
                     hasReceipt: true,
                     price: 20,
                     specs: {
@@ -116,7 +115,6 @@ export default {
                 {
                     id: 2,
                     name: '港澳通行证',
-                    badge: '含回执',
                     hasReceipt: true,
                     price: 20,
                     specs: {
@@ -134,7 +132,6 @@ export default {
                 {
                     id: 3,
                     name: '社保证',
-                    badge: '含回执',
                     hasReceipt: true,
                     price: 20,
                     specs: {
@@ -152,7 +149,6 @@ export default {
                 {
                     id: 4,
                     name: '护照',
-                    badge: '含回执',
                     hasReceipt: true,
                     price: 20,
                     specs: {
@@ -171,7 +167,6 @@ export default {
                 {
                     id: 5,
                     name: '驾驶证',
-                    badge: '标准证照',
                     hasReceipt: false,
                     price: 20,
                     specs: {
@@ -189,7 +184,6 @@ export default {
                 {
                     id: 6,
                     name: '工作证',
-                    badge: '标准证照',
                     hasReceipt: false,
                     price: 20,
                     specs: {
@@ -207,7 +201,6 @@ export default {
                 {
                     id: 7,
                     name: '学生证',
-                    badge: '标准证照',
                     hasReceipt: false,
                     price: 20,
                     specs: {
@@ -225,7 +218,6 @@ export default {
                 {
                     id: 8,
                     name: '居住证',
-                    badge: '标准证照',
                     hasReceipt: false,
                     price: 20,
                     specs: {
@@ -244,7 +236,6 @@ export default {
                 {
                     id: 9,
                     name: '美国签证',
-                    badge: '签证专用',
                     hasReceipt: false,
                     price: 20,
                     specs: {
@@ -262,7 +253,6 @@ export default {
                 {
                     id: 10,
                     name: '日本签证',
-                    badge: '签证专用',
                     hasReceipt: false,
                     price: 20,
                     specs: {
@@ -281,7 +271,6 @@ export default {
                 {
                     id: 11,
                     name: '公务员考试',
-                    badge: '考试专用',
                     hasReceipt: false,
                     price: 20,
                     specs: {
@@ -299,7 +288,6 @@ export default {
                 {
                     id: 12,
                     name: '教师资格证',
-                    badge: '考试专用',
                     hasReceipt: false,
                     price: 20,
                     specs: {
@@ -345,17 +333,16 @@ export default {
                 return
             }
             
-            // 模拟搜索逻辑 - 搜索名称、badge和specs相关字段
+            // 模拟搜索逻辑 - 搜索名称和规格相关字段
             this.searchResults = this.allDocuments.filter(doc => {
                 const nameMatch = doc.name.includes(keyword)
-                const badgeMatch = doc.badge.includes(keyword)
-                const specsMatch = 
+                const specsMatch =
                     doc.specs.printSize.includes(keyword) ||
                     doc.specs.pixelSize.includes(keyword) ||
                     doc.specs.resolution.includes(keyword) ||
                     doc.specs.imageFormat.includes(keyword) ||
                     doc.specs.requirements.includes(keyword)
-                return nameMatch || badgeMatch || specsMatch
+                return nameMatch || specsMatch
             })
         },
         


### PR DESCRIPTION
## Summary
- drop badge from certificate schema and models
- show receipt tag in miniapp when `hasReceipt`
- use color picker for background color in CMS

## Testing
- `mvn -q -e -DskipTests package` *(failed: Non-resolvable parent POM, Network is unreachable)*
- `npm run lint` *(failed: 'formName' is defined but never used)*
- `npx eslint src/view/certificate/certificate-create.vue src/view/certificate/certificate-list.vue && echo 'eslint success'`
- `npm test` *(failed: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c75fd26e4832584cee3f28f645e19