### PR TITLE
feat: add certificate category and miniapp API integration

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/dto/CertificateDTO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/dto/CertificateDTO.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 public class CertificateDTO {
     @NotBlank
     private String name;
+    private String category;
     private Boolean hasReceipt;
     private String printSize;
     private String pixelSize;

--- a/backend/src/main/java/io/github/talelin/latticy/model/CertificateDO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/model/CertificateDO.java
@@ -14,6 +14,7 @@ public class CertificateDO extends BaseModel implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private String name;
+    private String category;
     private Boolean hasReceipt;
     private String printSize;
     private String pixelSize;

--- a/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
+++ b/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
@@ -45,6 +45,7 @@ public class CertificateServiceImpl implements CertificateService {
 
     private void copyFields(CertificateDO target, CertificateDTO dto) {
         target.setName(dto.getName());
+        target.setCategory(dto.getCategory());
         target.setHasReceipt(dto.getHasReceipt());
         target.setPrintSize(dto.getPrintSize());
         target.setPixelSize(dto.getPixelSize());

--- a/backend/update.sql
+++ b/backend/update.sql
@@ -2,6 +2,7 @@ DROP TABLE IF EXISTS certificate;
 CREATE TABLE certificate (
   id INT AUTO_INCREMENT PRIMARY KEY,
   name VARCHAR(50) NOT NULL,
+  category VARCHAR(50),
   has_receipt TINYINT(1) DEFAULT 0,
   print_size VARCHAR(20),
   pixel_size VARCHAR(20),

--- a/cms-vue/src/view/certificate/certificate-create.vue
+++ b/cms-vue/src/view/certificate/certificate-create.vue
@@ -14,6 +14,9 @@
             <el-form-item label="含回执" prop="hasReceipt">
               <el-switch v-model="form.hasReceipt" />
             </el-form-item>
+            <el-form-item label="分类" prop="category">
+              <el-input v-model="form.category" placeholder="请输入分类" />
+            </el-form-item>
             <el-form-item label="价格" prop="price">
               <el-input-number v-model="form.price" :precision="2" :step="1" />
             </el-form-item>
@@ -73,6 +76,7 @@ export default {
       form: {
         name: '',
         hasReceipt: false,
+        category: '',
         price: 0,
         printSize: '',
         pixelSize: '',
@@ -94,15 +98,16 @@ export default {
   },
   async created() {
     const { id } = this.$route.query
-    if (id) {
-      this.isEdit = true
-      this.certificateId = id
-      const info = await certificate.getCertificate(id)
-      this.form = {
-        name: info.name,
-        hasReceipt: !!(info.has_receipt || info.hasReceipt),
-        price: info.price,
-        printSize: info.print_size || info.printSize,
+      if (id) {
+        this.isEdit = true
+        this.certificateId = id
+        const info = await certificate.getCertificate(id)
+        this.form = {
+          name: info.name,
+          hasReceipt: !!(info.has_receipt || info.hasReceipt),
+          category: info.category,
+          price: info.price,
+          printSize: info.print_size || info.printSize,
         pixelSize: info.pixel_size || info.pixelSize,
         resolution: info.resolution,
         saveElectronicPhoto: !!(info.save_electronic_photo || info.saveElectronicPhoto),
@@ -139,6 +144,7 @@ export default {
       const submitData = {
         name: this.form.name,
         has_receipt: this.form.hasReceipt,
+        category: this.form.category,
         price: this.form.price,
         print_size: this.form.printSize,
         pixel_size: this.form.pixelSize,

--- a/cms-vue/src/view/certificate/certificate-list.vue
+++ b/cms-vue/src/view/certificate/certificate-list.vue
@@ -27,6 +27,7 @@ export default {
     return {
       tableColumn: [
         { prop: 'name', label: '名称' },
+        { prop: 'category', label: '分类' },
         { prop: 'hasReceipt', label: '含回执' },
         { prop: 'price', label: '价格' },
         { prop: 'printSize', label: '打印尺寸' },

--- a/miniapp/zfb-uniapp/mock/certificates.js
+++ b/miniapp/zfb-uniapp/mock/certificates.js
@@ -1,0 +1,38 @@
+export default [
+  {
+    id: 1,
+    name: '身份证',
+    category: '回执',
+    hasReceipt: true,
+    price: 20,
+    specs: {
+      printSize: '26x32mm',
+      pixelSize: '358x441px',
+      resolution: '300DPI',
+      saveElectronicPhoto: true,
+      printLayout: true,
+      bgColor: '#FFFFFF',
+      imageFormat: 'JPEG',
+      imageFileSize: '20KB-50KB',
+      requirements: '免冠，照片可看见两耳轮廓'
+    }
+  },
+  {
+    id: 2,
+    name: '护照',
+    category: '证照',
+    hasReceipt: false,
+    price: 20,
+    specs: {
+      printSize: '33x48mm',
+      pixelSize: '390x567px',
+      resolution: '300DPI',
+      saveElectronicPhoto: true,
+      printLayout: true,
+      bgColor: '#FFFFFF',
+      imageFormat: 'JPEG',
+      imageFileSize: '30KB-80KB',
+      requirements: '免冠，照片可看见两耳轮廓'
+    }
+  }
+]

--- a/miniapp/zfb-uniapp/pages/main/components/home-content.vue
+++ b/miniapp/zfb-uniapp/pages/main/components/home-content.vue
@@ -98,6 +98,8 @@
 
 <script>
 import ScrollBanner from '@/components/scroll-banner.vue'
+import { getCertificates } from '@/utils/api.js'
+import mockCertificates from '@/mock/certificates.js'
 
 export default {
   name: 'HomeContent',
@@ -115,273 +117,8 @@ export default {
         { id: 3, name: '考试', icon: '📝' },
         { id: 4, name: '近期', icon: '🕐' }
       ],
-      documentsData: {
-        0: [ // 回执
-          {
-            id: 1,
-            name: '身份证',
-            hasReceipt: true,
-            price: 20,
-            specs: {
-              printSize: '26x32mm',
-              pixelSize: '358x441px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: '无要求',
-              imageFileSize: '无要求',
-              requirements: '免冠，照片可看见两耳轮廓和相当于男士喉结处的地方'
-            }
-          },
-          {
-            id: 2,
-            name: '港澳通行证',
-            hasReceipt: true,
-            price: 20,
-            specs: {
-              printSize: '33x48mm',
-              pixelSize: '390x567px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: 'JPEG',
-              imageFileSize: '20KB-50KB',
-              requirements: '免冠正面照，头部占照片面积的2/3，白色背景'
-            }
-          },
-          {
-            id: 3,
-            name: '社保证',
-            hasReceipt: true,
-            price: 20,
-            specs: {
-              printSize: '26x32mm',
-              pixelSize: '358x441px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: '无要求',
-              imageFileSize: '无要求',
-              requirements: '免冠正面照，表情自然，双眼睁开'
-            }
-          },
-          {
-            id: 4,
-            name: '护照',
-            hasReceipt: true,
-            price: 20,
-            specs: {
-              printSize: '33x48mm',
-              pixelSize: '390x567px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: 'JPEG',
-              imageFileSize: '40KB-120KB',
-              requirements: '免冠正面照，不得佩戴帽子或头巾，白色背景'
-            }
-          }
-        ],
-        1: [ // 证照
-          {
-            id: 5,
-            name: '驾驶证',
-            hasReceipt: false,
-            price: 20,
-            specs: {
-              printSize: '22x32mm',
-              pixelSize: '260x378px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: 'JPEG',
-              imageFileSize: '无要求',
-              requirements: '免冠正面照，不得戴有色眼镜，白色背景'
-            }
-          },
-          {
-            id: 6,
-            name: '工作证',
-            hasReceipt: false,
-            price: 20,
-            specs: {
-              printSize: '25x35mm',
-              pixelSize: '295x413px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: '无要求',
-              imageFileSize: '无要求',
-              requirements: '免冠正面照，着正装，表情严肃自然'
-            }
-          },
-          {
-            id: 7,
-            name: '学生证',
-            hasReceipt: false,
-            price: 20,
-            specs: {
-              printSize: '26x32mm',
-              pixelSize: '358x441px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: '无要求',
-              imageFileSize: '无要求',
-              requirements: '免冠正面照，表情自然，着装整洁'
-            }
-          }
-        ],
-        2: [ // 签证
-          {
-            id: 8,
-            name: '美国签证',
-            hasReceipt: false,
-            price: 20,
-            specs: {
-              printSize: '51x51mm',
-              pixelSize: '600x600px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: 'JPEG',
-              imageFileSize: '240KB以下',
-              requirements: '正方形照片，头部占照片50%-69%，6个月内拍摄'
-            }
-          },
-          {
-            id: 9,
-            name: '日本签证',
-            hasReceipt: false,
-            price: 20,
-            specs: {
-              printSize: '45x45mm',
-              pixelSize: '531x531px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: 'JPEG',
-              imageFileSize: '无要求',
-              requirements: '正方形照片，头顶到下颌长度占总长度70%-80%'
-            }
-          },
-          {
-            id: 10,
-            name: '韩国签证',
-            hasReceipt: false,
-            price: 20,
-            specs: {
-              printSize: '35x45mm',
-              pixelSize: '413x531px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: 'JPEG',
-              imageFileSize: '无要求',
-              requirements: '免冠正面照，头部占照片2/3，6个月内拍摄'
-            }
-          }
-        ],
-        3: [ // 考试
-          {
-            id: 11,
-            name: '公务员考试',
-            hasReceipt: false,
-            price: 20,
-            specs: {
-              printSize: '25x35mm',
-              pixelSize: '295x413px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: 'JPEG',
-              imageFileSize: '20KB-50KB',
-              requirements: '免冠正面照，着正装，表情严肃，近期拍摄'
-            }
-          },
-          {
-            id: 12,
-            name: '教师资格证',
-            hasReceipt: false,
-            price: 20,
-            specs: {
-              printSize: '25x35mm',
-              pixelSize: '295x413px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: 'JPEG',
-              imageFileSize: '200KB以下',
-              requirements: '免冠正面照，不得佩戴首饰，着装整洁'
-            }
-          },
-          {
-            id: 13,
-            name: '会计师考试',
-            hasReceipt: false,
-            price: 20,
-            specs: {
-              printSize: '26x32mm',
-              pixelSize: '358x441px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: 'JPEG',
-              imageFileSize: '无要求',
-              requirements: '免冠正面照，着正装，表情自然严肃'
-            }
-          }
-        ],
-        4: [ // 近期
-          {
-            id: 14,
-            name: '身份证',
-            hasReceipt: true,
-            price: 20,
-            specs: {
-              printSize: '26x32mm',
-              pixelSize: '358x441px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: '无要求',
-              imageFileSize: '无要求',
-              requirements: '免冠，照片可看见两耳轮廓和相当于男士喉结处的地方'
-            }
-          },
-          {
-            id: 15,
-            name: '护照',
-            hasReceipt: true,
-            price: 20,
-            specs: {
-              printSize: '33x48mm',
-              pixelSize: '390x567px',
-              resolution: '300DPI',
-              saveElectronicPhoto: true,
-              printLayout: true,
-              bgColor: '#FFFFFF',
-              imageFormat: 'JPEG',
-              imageFileSize: '40KB-120KB',
-              requirements: '免冠正面照，不得佩戴帽子或头巾，白色背景'
-            }
-          }
-        ]
-      },
+      documentsData: {},
+      allDocuments: [],
       bannerImages: [
         {
           src: '/static/banner/banner1.png',
@@ -406,12 +143,37 @@ export default {
   mounted() {
     // 监听城市选择事件
     uni.$on('citySelected', this.onCitySelected)
+    this.loadCertificates()
   },
   beforeDestroy() {
     // 移除事件监听
     uni.$off('citySelected', this.onCitySelected)
   },
   methods: {
+    async loadCertificates() {
+      try {
+        const list = await getCertificates()
+        this.allDocuments = list
+      } catch (e) {
+        this.allDocuments = mockCertificates
+      }
+      this.groupDocuments()
+    },
+    groupDocuments() {
+      const grouped = {}
+      this.allDocuments.forEach(doc => {
+        if (!grouped[doc.category]) grouped[doc.category] = []
+        grouped[doc.category].push(doc)
+      })
+      this.documentsData = {}
+      this.categories.forEach((cat, index) => {
+        if (cat.name === '近期') {
+          this.documentsData[index] = this.allDocuments.slice(0, 5)
+        } else {
+          this.documentsData[index] = grouped[cat.name] || []
+        }
+      })
+    },
     onCitySelect() {
       console.log('选择城市')
       // 跳转到城市选择页面

--- a/miniapp/zfb-uniapp/pages/search/search.vue
+++ b/miniapp/zfb-uniapp/pages/search/search.vue
@@ -85,6 +85,8 @@
 </template>
 
 <script>
+import { getCertificates } from '@/utils/api.js'
+import mockCertificates from '@/mock/certificates.js'
 export default {
     name: 'SearchPage',
     data() {
@@ -92,220 +94,10 @@ export default {
             currentCity: '重庆',
             searchKeyword: '',
             searchResults: [],
-            // 模拟搜索数据 - 与home-content保持一致的数据格式
-            allDocuments: [
-                // 回执类证件
-                {
-                    id: 1,
-                    name: '身份证',
-                    hasReceipt: true,
-                    price: 20,
-                    specs: {
-                        printSize: '26x32mm',
-                        pixelSize: '358x441px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: '无要求',
-                        imageFileSize: '无要求',
-                        requirements: '免冠，照片可看见两耳轮廓和相当于男士喉结处的地方'
-                    }
-                },
-                {
-                    id: 2,
-                    name: '港澳通行证',
-                    hasReceipt: true,
-                    price: 20,
-                    specs: {
-                        printSize: '33x48mm',
-                        pixelSize: '390x567px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: 'JPEG',
-                        imageFileSize: '20KB-50KB',
-                        requirements: '免冠正面照，头部占照片面积的2/3，白色背景'
-                    }
-                },
-                {
-                    id: 3,
-                    name: '社保证',
-                    hasReceipt: true,
-                    price: 20,
-                    specs: {
-                        printSize: '26x32mm',
-                        pixelSize: '358x441px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: '无要求',
-                        imageFileSize: '无要求',
-                        requirements: '免冠正面照，表情自然，双眼睁开'
-                    }
-                },
-                {
-                    id: 4,
-                    name: '护照',
-                    hasReceipt: true,
-                    price: 20,
-                    specs: {
-                        printSize: '33x48mm',
-                        pixelSize: '390x567px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: 'JPEG',
-                        imageFileSize: '40KB-120KB',
-                        requirements: '免冠正面照，不得佩戴帽子或头巾，白色背景'
-                    }
-                },
-                // 证照类
-                {
-                    id: 5,
-                    name: '驾驶证',
-                    hasReceipt: false,
-                    price: 20,
-                    specs: {
-                        printSize: '22x32mm',
-                        pixelSize: '260x378px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: 'JPEG',
-                        imageFileSize: '无要求',
-                        requirements: '免冠正面照，不得戴有色眼镜，白色背景'
-                    }
-                },
-                {
-                    id: 6,
-                    name: '工作证',
-                    hasReceipt: false,
-                    price: 20,
-                    specs: {
-                        printSize: '25x35mm',
-                        pixelSize: '295x413px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: '无要求',
-                        imageFileSize: '无要求',
-                        requirements: '免冠正面照，着正装，表情严肃自然'
-                    }
-                },
-                {
-                    id: 7,
-                    name: '学生证',
-                    hasReceipt: false,
-                    price: 20,
-                    specs: {
-                        printSize: '26x32mm',
-                        pixelSize: '358x441px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: '无要求',
-                        imageFileSize: '无要求',
-                        requirements: '免冠正面照，表情自然，着装整洁'
-                    }
-                },
-                {
-                    id: 8,
-                    name: '居住证',
-                    hasReceipt: false,
-                    price: 20,
-                    specs: {
-                        printSize: '26x32mm',
-                        pixelSize: '358x441px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: '无要求',
-                        imageFileSize: '无要求',
-                        requirements: '免冠正面照，表情自然，白色背景'
-                    }
-                },
-                // 签证类
-                {
-                    id: 9,
-                    name: '美国签证',
-                    hasReceipt: false,
-                    price: 20,
-                    specs: {
-                        printSize: '51x51mm',
-                        pixelSize: '600x600px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: 'JPEG',
-                        imageFileSize: '240KB以下',
-                        requirements: '正方形照片，头部占照片50%-69%，6个月内拍摄'
-                    }
-                },
-                {
-                    id: 10,
-                    name: '日本签证',
-                    hasReceipt: false,
-                    price: 20,
-                    specs: {
-                        printSize: '45x45mm',
-                        pixelSize: '531x531px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: 'JPEG',
-                        imageFileSize: '无要求',
-                        requirements: '正方形照片，头顶到下颌长度占总长度70%-80%'
-                    }
-                },
-                // 考试类
-                {
-                    id: 11,
-                    name: '公务员考试',
-                    hasReceipt: false,
-                    price: 20,
-                    specs: {
-                        printSize: '25x35mm',
-                        pixelSize: '295x413px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: 'JPEG',
-                        imageFileSize: '20KB-50KB',
-                        requirements: '免冠正面照，着正装，表情严肃，近期拍摄'
-                    }
-                },
-                {
-                    id: 12,
-                    name: '教师资格证',
-                    hasReceipt: false,
-                    price: 20,
-                    specs: {
-                        printSize: '25x35mm',
-                        pixelSize: '295x413px',
-                        resolution: '300DPI',
-                        saveElectronicPhoto: true,
-                        printLayout: true,
-                        bgColor: '#FFFFFF',
-                        imageFormat: 'JPEG',
-                        imageFileSize: '200KB以下',
-                        requirements: '免冠正面照，不得佩戴首饰，着装整洁'
-                    }
-                }
-            ]
+            allDocuments: []
         }
     },
-    onLoad(options) {
+    async onLoad(options) {
         console.log('搜索页面加载完成')
         // 接收传入的城市参数
         if (options.city) {
@@ -314,10 +106,21 @@ export default {
         // 接收传入的搜索关键词
         if (options.keyword) {
             this.searchKeyword = decodeURIComponent(options.keyword)
+        }
+        await this.loadCertificates()
+        if (this.searchKeyword) {
             this.performSearch(this.searchKeyword)
         }
     },
     methods: {
+        async loadCertificates() {
+            try {
+                const list = await getCertificates()
+                this.allDocuments = list
+            } catch (e) {
+                this.allDocuments = mockCertificates
+            }
+        },
         onSearchInput(e) {
             const keyword = e.detail.value
             this.searchKeyword = keyword

--- a/miniapp/zfb-uniapp/utils/api.js
+++ b/miniapp/zfb-uniapp/utils/api.js
@@ -1,0 +1,33 @@
+const API_BASE = 'http://localhost:8080/v1/mini'
+
+export function getCertificates() {
+  return new Promise((resolve, reject) => {
+    uni.request({
+      url: `${API_BASE}/certificate`,
+      method: 'GET',
+      success: (res) => {
+        const list = res.data && res.data.data ? res.data.data : res.data
+        const mapped = (list || []).map(item => ({
+          ...item,
+          specs: {
+            printSize: item.printSize,
+            pixelSize: item.pixelSize,
+            resolution: item.resolution,
+            saveElectronicPhoto: item.saveElectronicPhoto,
+            printLayout: item.printLayout,
+            bgColor: item.bgColor,
+            imageFormat: item.imageFormat,
+            imageFileSize: item.imageFileSize,
+            requirements: item.requirements
+          }
+        }))
+        resolve(mapped)
+      },
+      fail: (err) => reject(err)
+    })
+  })
+}
+
+export default {
+  getCertificates
+}


### PR DESCRIPTION
## Summary
- add `category` column for certificates and wire it through backend service
- expose category management in CMS
- fetch certificate data via API in miniapp home and search pages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_689c9c6e3e9c8325916a9c58b94d237a