### PR TITLE
feat: add certificate search

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/controller/v1/CertificateController.java
+++ b/backend/src/main/java/io/github/talelin/latticy/controller/v1/CertificateController.java
@@ -32,7 +32,10 @@ public class CertificateController {
     }
 
     @GetMapping("")
-    public List<CertificateDO> getAll() {
+    public List<CertificateDO> getAll(@RequestParam(value = "keyword", required = false) String keyword) {
+        if (keyword != null && !keyword.isEmpty()) {
+            return certificateService.search(keyword);
+        }
         return certificateService.findAll();
     }
 

--- a/backend/src/main/java/io/github/talelin/latticy/controller/v1/CertificateMiniController.java
+++ b/backend/src/main/java/io/github/talelin/latticy/controller/v1/CertificateMiniController.java
@@ -19,7 +19,10 @@ public class CertificateMiniController {
     private CertificateService certificateService;
 
     @GetMapping("")
-    public List<CertificateDO> getAll() {
+    public List<CertificateDO> getAll(@RequestParam(value = "keyword", required = false) String keyword) {
+        if (keyword != null && !keyword.isEmpty()) {
+            return certificateService.search(keyword);
+        }
         return certificateService.findAll();
     }
 

--- a/backend/src/main/java/io/github/talelin/latticy/service/CertificateService.java
+++ b/backend/src/main/java/io/github/talelin/latticy/service/CertificateService.java
@@ -10,5 +10,6 @@ public interface CertificateService {
     boolean update(CertificateDO certificate, CertificateDTO dto);
     CertificateDO getById(Integer id);
     List<CertificateDO> findAll();
+    List<CertificateDO> search(String keyword);
     boolean deleteById(Integer id);
 }

--- a/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
+++ b/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
@@ -4,6 +4,7 @@ import io.github.talelin.latticy.dto.CertificateDTO;
 import io.github.talelin.latticy.mapper.CertificateMapper;
 import io.github.talelin.latticy.model.CertificateDO;
 import io.github.talelin.latticy.service.CertificateService;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -36,6 +37,13 @@ public class CertificateServiceImpl implements CertificateService {
     @Override
     public List<CertificateDO> findAll() {
         return certificateMapper.selectList(null);
+    }
+
+    @Override
+    public List<CertificateDO> search(String keyword) {
+        QueryWrapper<CertificateDO> wrapper = new QueryWrapper<>();
+        wrapper.lambda().like(CertificateDO::getName, keyword);
+        return certificateMapper.selectList(wrapper);
     }
 
     @Override

--- a/miniapp/zfb-uniapp/pages/search/search.vue
+++ b/miniapp/zfb-uniapp/pages/search/search.vue
@@ -93,8 +93,7 @@ export default {
         return {
             currentCity: '重庆',
             searchKeyword: '',
-            searchResults: [],
-            allDocuments: []
+            searchResults: []
         }
     },
     async onLoad(options) {
@@ -107,46 +106,39 @@ export default {
         if (options.keyword) {
             this.searchKeyword = decodeURIComponent(options.keyword)
         }
-        await this.loadCertificates()
         if (this.searchKeyword) {
-            this.performSearch(this.searchKeyword)
+            await this.performSearch(this.searchKeyword)
         }
     },
     methods: {
-        async loadCertificates() {
-            try {
-                const list = await getCertificates()
-                this.allDocuments = list
-            } catch (e) {
-                this.allDocuments = mockCertificates
-            }
-        },
         onSearchInput(e) {
             const keyword = e.detail.value
             this.searchKeyword = keyword
             this.performSearch(keyword)
         },
-        
-        performSearch(keyword) {
-            // 触发搜索事件，传入地区和关键词参数
+
+        async performSearch(keyword) {
             this.handleSearchEvent(this.currentCity, keyword)
-            
+
             if (!keyword.trim()) {
                 this.searchResults = []
                 return
             }
-            
-            // 模拟搜索逻辑 - 搜索名称和规格相关字段
-            this.searchResults = this.allDocuments.filter(doc => {
-                const nameMatch = doc.name.includes(keyword)
-                const specsMatch =
-                    doc.printSize.includes(keyword) ||
-                    doc.pixelSize.includes(keyword) ||
-                    doc.resolution.includes(keyword) ||
-                    doc.imageFormat.includes(keyword) ||
-                    doc.requirements.includes(keyword)
-                return nameMatch || specsMatch
-            })
+
+            try {
+                this.searchResults = await getCertificates(keyword)
+            } catch (e) {
+                this.searchResults = mockCertificates.filter(doc => {
+                    const nameMatch = doc.name.includes(keyword)
+                    const specsMatch =
+                        doc.specs.printSize.includes(keyword) ||
+                        doc.specs.pixelSize.includes(keyword) ||
+                        doc.specs.resolution.includes(keyword) ||
+                        doc.specs.imageFormat.includes(keyword) ||
+                        doc.specs.requirements.includes(keyword)
+                    return nameMatch || specsMatch
+                })
+            }
         },
         
         handleSearchEvent(city, keyword) {

--- a/miniapp/zfb-uniapp/utils/api.js
+++ b/miniapp/zfb-uniapp/utils/api.js
@@ -1,9 +1,12 @@
 const API_BASE = 'http://localhost:8080/v1/mini'
 
-export function getCertificates() {
+export function getCertificates(keyword = '') {
   return new Promise((resolve, reject) => {
+    const url = keyword
+      ? `${API_BASE}/certificate?keyword=${encodeURIComponent(keyword)}`
+      : `${API_BASE}/certificate`
     uni.request({
-      url: `${API_BASE}/certificate`,
+      url,
       method: 'GET',
       success: (res) => {
         const list = res.data && res.data.data ? res.data.data : res.data


### PR DESCRIPTION
## Summary
- add keyword search in certificate service and controllers
- wire miniapp search page to backend search API

## Testing
- `npm test` *(fails: Could not read package.json)*
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.2.5.RELEASE)*

------
https://chatgpt.com/codex/tasks/task_e_689caffc909083259cffced2dc0ff706