### PR TITLE
feat: add alipay login flow

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/common/constant/IdentityConstant.java
+++ b/backend/src/main/java/io/github/talelin/latticy/common/constant/IdentityConstant.java
@@ -12,4 +12,9 @@ public class IdentityConstant {
      */
     public static final String USERNAME_PASSWORD_IDENTITY = "USERNAME_PASSWORD";
 
+    /**
+     * 表示通过支付宝进行身份认证
+     */
+    public static final String ALIPAY_IDENTITY = "ALIPAY";
+
 }

--- a/backend/src/main/java/io/github/talelin/latticy/controller/v1/AuthController.java
+++ b/backend/src/main/java/io/github/talelin/latticy/controller/v1/AuthController.java
@@ -1,0 +1,67 @@
+package io.github.talelin.latticy.controller.v1;
+
+import com.alipay.api.AlipayApiException;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import io.github.talelin.core.token.DoubleJWT;
+import io.github.talelin.core.token.Tokens;
+import io.github.talelin.latticy.common.constant.IdentityConstant;
+import io.github.talelin.latticy.dto.auth.AlipayLoginDTO;
+import io.github.talelin.latticy.model.UserDO;
+import io.github.talelin.latticy.model.UserIdentityDO;
+import io.github.talelin.latticy.service.AlipayService;
+import io.github.talelin.latticy.service.UserIdentityService;
+import io.github.talelin.latticy.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/v1/auth")
+@Validated
+public class AuthController {
+
+    @Autowired
+    private AlipayService alipayService;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserIdentityService userIdentityService;
+
+    @Autowired
+    private DoubleJWT jwt;
+
+    @PostMapping("/alipay")
+    public Map<String, Object> alipayLogin(@RequestBody @Validated AlipayLoginDTO dto) throws AlipayApiException {
+        String alipayUserId = alipayService.getUserId(dto.getAuthCode());
+        QueryWrapper<UserIdentityDO> wrapper = new QueryWrapper<>();
+        wrapper.lambda()
+                .eq(UserIdentityDO::getIdentityType, IdentityConstant.ALIPAY_IDENTITY)
+                .eq(UserIdentityDO::getIdentifier, alipayUserId);
+        UserIdentityDO identity = userIdentityService.getOne(wrapper);
+        UserDO user;
+        if (identity == null) {
+            user = UserDO.builder()
+                    .username("alipay_" + alipayUserId)
+                    .nickname("支付宝用户")
+                    .build();
+            userService.save(user);
+            userIdentityService.createIdentity(user.getId(), IdentityConstant.ALIPAY_IDENTITY, alipayUserId, "");
+        } else {
+            user = userService.getById(identity.getUserId());
+        }
+        Tokens tokens = jwt.generateTokens(user.getId());
+        Map<String, Object> data = new HashMap<>();
+        data.put("token", tokens.getAccessToken());
+        data.put("refreshToken", tokens.getRefreshToken());
+        Map<String, Object> res = new HashMap<>();
+        res.put("code", 0);
+        res.put("message", "ok");
+        res.put("data", data);
+        return res;
+    }
+}

--- a/backend/src/main/java/io/github/talelin/latticy/dto/auth/AlipayLoginDTO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/dto/auth/AlipayLoginDTO.java
@@ -1,0 +1,18 @@
+package io.github.talelin.latticy.dto.auth;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * 支付宝登录 DTO
+ */
+@Data
+public class AlipayLoginDTO {
+
+    /**
+     * 小程序获取到的 authCode
+     */
+    @NotBlank(message = "authCode不能为空")
+    private String authCode;
+}


### PR DESCRIPTION
## Summary
- enable Alipay authCode exchange and user binding on backend
- add login button on miniapp profile page and persist JWT
- inject stored token into all miniapp API requests
- polish login button and populate avatar/nickname from Alipay user info

## Testing
- `npm test` *(fails: Could not read package.json)*
- `mvn -q -f backend/pom.xml -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.2.5.RELEASE)*

------
https://chatgpt.com/codex/tasks/task_e_689d6080ead88325b70b19d71dc269aa