### PR TITLE
feat: sync alipay user profile

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/controller/v1/AuthController.java
+++ b/backend/src/main/java/io/github/talelin/latticy/controller/v1/AuthController.java
@@ -47,12 +47,16 @@ public class AuthController {
         if (identity == null) {
             user = UserDO.builder()
                     .username("alipay_" + alipayUserId)
-                    .nickname("支付宝用户")
+                    .nickname(dto.getNickname())
+                    .avatar(dto.getAvatar())
                     .build();
             userService.save(user);
             userIdentityService.createIdentity(user.getId(), IdentityConstant.ALIPAY_IDENTITY, alipayUserId, "");
         } else {
             user = userService.getById(identity.getUserId());
+            user.setNickname(dto.getNickname());
+            user.setAvatar(dto.getAvatar());
+            userService.updateById(user);
         }
         Tokens tokens = jwt.generateTokens(user.getId());
         Map<String, Object> data = new HashMap<>();

--- a/backend/src/main/java/io/github/talelin/latticy/dto/auth/AlipayLoginDTO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/dto/auth/AlipayLoginDTO.java
@@ -19,4 +19,18 @@ public class AlipayLoginDTO {
     @JsonProperty("authCode")
     @JsonAlias({"authcode", "auth_code"})
     private String authCode;
+
+    /**
+     * 用户昵称
+     */
+    @NotBlank(message = "nickName不能为空")
+    @JsonProperty("nickName")
+    @JsonAlias({"nickname", "nick_name"})
+    private String nickname;
+
+    /**
+     * 用户头像
+     */
+    @NotBlank(message = "avatar不能为空")
+    private String avatar;
 }


### PR DESCRIPTION
## Summary
- obtain user nickName and avatar during Alipay login
- backend saves latest nickName and avatar for each login

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d6d22a7508325b1e9050dcfead500