### PR TITLE
feat: support dev-mode payment simulation

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/controller/v1/AlipayController.java
+++ b/backend/src/main/java/io/github/talelin/latticy/controller/v1/AlipayController.java
@@ -3,8 +3,14 @@ package io.github.talelin.latticy.controller.v1;
 import com.alipay.api.AlipayApiException;
 import io.github.talelin.latticy.service.AlipayService;
 import io.github.talelin.latticy.service.PhotoOrderService;
+import io.github.talelin.latticy.dto.AlipayNotifyTestDTO;
+import io.github.talelin.latticy.vo.UnifyResponseVO;
+import io.github.talelin.autoconfigure.exception.ForbiddenException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,6 +20,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/v1/alipay")
+@Validated
 public class AlipayController {
 
     @Autowired
@@ -21,6 +28,9 @@ public class AlipayController {
 
     @Autowired
     private PhotoOrderService photoOrderService;
+
+    @Autowired
+    private Environment environment;
 
     @PostMapping("/notify")
     public String notify(HttpServletRequest request) throws AlipayApiException {
@@ -35,5 +45,27 @@ public class AlipayController {
             return "success";
         }
         return "failure";
+    }
+
+    @PostMapping("/notify/test")
+    public UnifyResponseVO<String> notifyTest(@RequestBody @Validated AlipayNotifyTestDTO dto) {
+        String[] profiles = environment.getActiveProfiles();
+        boolean dev = false;
+        if (profiles != null) {
+            for (String p : profiles) {
+                if ("dev".equals(p)) {
+                    dev = true;
+                    break;
+                }
+            }
+        }
+        if (!dev) {
+            throw new ForbiddenException(10003);
+        }
+        if ("TRADE_SUCCESS".equals(dto.getTradeStatus())) {
+            photoOrderService.markPaid(dto.getOutTradeNo());
+            return new UnifyResponseVO<>("success");
+        }
+        return new UnifyResponseVO<>("failure");
     }
 }

--- a/backend/src/main/java/io/github/talelin/latticy/dto/AlipayNotifyTestDTO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/dto/AlipayNotifyTestDTO.java
@@ -1,0 +1,16 @@
+package io.github.talelin.latticy.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@Data
+public class AlipayNotifyTestDTO {
+    @NotBlank
+    @JsonProperty("out_trade_no")
+    private String outTradeNo;
+
+    @JsonProperty("trade_status")
+    private String tradeStatus;
+}

--- a/backend/src/main/java/io/github/talelin/latticy/service/PhotoOrderService.java
+++ b/backend/src/main/java/io/github/talelin/latticy/service/PhotoOrderService.java
@@ -47,6 +47,7 @@ public class PhotoOrderService extends ServiceImpl<PhotoOrderMapper, PhotoOrderD
         Map<String, Object> res = new HashMap<>();
         res.put("orderId", order.getId());
         res.put("tradeNo", tradeNo);
+        res.put("orderNo", order.getOrderNo());
         return res;
     }
 

--- a/miniapp/zfb-uniapp/pages/order-submit/order-submit.vue
+++ b/miniapp/zfb-uniapp/pages/order-submit/order-submit.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script>
-import { createOrder } from '@/utils/api.js'
+import { createOrder, alipayNotifyTest } from '@/utils/api.js'
 
 export default {
   name: 'OrderSubmit',
@@ -172,20 +172,32 @@ export default {
         .then(res => {
           uni.hideLoading()
           const tradeNo = res.data.tradeNo
-          my.tradePay({
-            tradeNO: tradeNo,
-            success: result => {
-              if (result.resultCode === '9000') {
+          const orderNo = res.data.orderNo
+          if (res.__isDev__) {
+            alipayNotifyTest({ out_trade_no: orderNo, trade_status: 'TRADE_SUCCESS' })
+              .then(() => {
                 uni.showToast({ title: '支付成功', icon: 'success' })
                 uni.navigateBack({ delta: 1 })
-              } else {
+              })
+              .catch(() => {
                 uni.showToast({ title: '支付失败', icon: 'none' })
+              })
+          } else {
+            my.tradePay({
+              tradeNO: tradeNo,
+              success: result => {
+                if (result.resultCode === '9000') {
+                  uni.showToast({ title: '支付成功', icon: 'success' })
+                  uni.navigateBack({ delta: 1 })
+                } else {
+                  uni.showToast({ title: '支付失败', icon: 'none' })
+                }
+              },
+              fail: () => {
+                uni.showToast({ title: '支付取消', icon: 'none' })
               }
-            },
-            fail: () => {
-              uni.showToast({ title: '支付取消', icon: 'none' })
-            }
-          })
+            })
+          }
         })
         .catch(() => {
           uni.hideLoading()

--- a/miniapp/zfb-uniapp/utils/api.js
+++ b/miniapp/zfb-uniapp/utils/api.js
@@ -2,6 +2,18 @@ const API_BASE = 'http://192.168.31.179:5000/v1/mini'
 const TOKEN_KEY = 'token'
 const REFRESH_TOKEN_KEY = 'refreshToken'
 
+function isLanHost(hostname) {
+  return /^127\.|^localhost$|^10\.|^172\.(1[6-9]|2[0-9]|3[0-1])\.|^192\.168\./.test(hostname)
+}
+
+let IS_DEV = false
+try {
+  const host = new URL(API_BASE).hostname
+  IS_DEV = isLanHost(host)
+} catch (e) {
+  IS_DEV = false
+}
+
 // 通用请求封装函数
 function request(url, method = 'GET', data = null, options = {}, retry = true) {
   return new Promise((resolve, reject) => {
@@ -47,6 +59,9 @@ function request(url, method = 'GET', data = null, options = {}, retry = true) {
           return
         }
         if (res.statusCode >= 200 && res.statusCode < 300) {
+          if (IS_DEV && res.data && typeof res.data === 'object') {
+            res.data.__isDev__ = true
+          }
           resolve(res.data)
         } else {
           reject(new Error(`请求失败: ${res.statusCode}`))
@@ -110,3 +125,4 @@ export function resubmitOrder(id, data) {
 
 export const alipayLogin = Post('/auth/alipay')
 export const refreshToken = () => refreshTokenRequest()
+export const alipayNotifyTest = Post('/../alipay/notify/test')


### PR DESCRIPTION
## Summary
- tag API responses with `__isDev__` when hitting a LAN host
- simulate payment in miniapp order submission when running in dev
- add backend Alipay test notify endpoint gated by dev profile

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.2.5.RELEASE)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c1bd1af08325bb4d7b746f15f635