### PR TITLE
feat: add order photo viewer

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/controller/v1/PhotoOrderController.java
+++ b/backend/src/main/java/io/github/talelin/latticy/controller/v1/PhotoOrderController.java
@@ -71,7 +71,7 @@ public class PhotoOrderController {
     }
 
     @GetMapping("/{id}/photos")
-    @LoginRequired
+    @GroupRequired
     public Map<String, String> photos(@PathVariable("id") @Positive Long id) {
         return photoOrderService.getPhotos(id);
     }

--- a/cms-vue/src/component/base/table/lin-table.vue
+++ b/cms-vue/src/component/base/table/lin-table.vue
@@ -51,16 +51,18 @@
       </el-table-column>
       <el-table-column v-if="operate.length > 0" label="操作" fixed="right" width="275">
         <template slot-scope="scope">
-          <el-button
-            v-for="(item, index) in operate"
-            :type="item.type"
-            plain
-            :key="index"
-            size="mini"
-            v-permission="{ permission: item.permission ? item.permission : '', type: 'disabled' }"
-            @click.native.prevent.stop="buttonMethods(item.func, scope.$index, scope.row)"
-            >{{ item.name }}</el-button
-          >
+          <template v-for="(item, index) in operate">
+            <el-button
+              v-if="!item.show || item.show(scope.row)"
+              :type="item.type"
+              plain
+              :key="index"
+              size="mini"
+              v-permission="{ permission: item.permission ? item.permission : '', type: 'disabled' }"
+              @click.native.prevent.stop="buttonMethods(item.func, scope.$index, scope.row)"
+              >{{ item.name }}</el-button
+            >
+          </template>
         </template>
       </el-table-column>
     </el-table>

--- a/cms-vue/src/model/photo-order.js
+++ b/cms-vue/src/model/photo-order.js
@@ -1,10 +1,14 @@
 /* eslint-disable class-methods-use-this */
-import _axios, { get, post } from '@/lin/plugin/axios'
+import { get, post } from '@/lin/plugin/axios'
 
 class PhotoOrder {
   async getOrders() {
     const res = await get('v1/mini/order')
     return res
+  }
+
+  async getPhotos(id) {
+    return get(`v1/mini/order/${id}/photos`)
   }
 
   async reject(id, reason) {

--- a/cms-vue/src/view/photo-order/photo-order-detail.vue
+++ b/cms-vue/src/view/photo-order/photo-order-detail.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="container">
+    <div class="title">
+      <span>查看订单</span>
+      <span class="back" @click="back"> <i class="iconfont icon-fanhui"></i> 返回 </span>
+    </div>
+    <el-divider></el-divider>
+    <div class="img-list">
+      <div class="img-item" v-if="photos.standardPhoto">
+        <div class="label">标准照</div>
+        <el-image :src="photos.standardPhoto" :preview-src-list="[photos.standardPhoto]" />
+      </div>
+      <div class="img-item" v-if="photos.layoutPhoto">
+        <div class="label">排版照</div>
+        <el-image :src="photos.layoutPhoto" :preview-src-list="[photos.layoutPhoto]" />
+      </div>
+      <div class="img-item" v-if="photos.receiptPhoto">
+        <div class="label">回执照</div>
+        <el-image :src="photos.receiptPhoto" :preview-src-list="[photos.receiptPhoto]" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import photoOrder from '@/model/photo-order'
+
+export default {
+  props: {
+    orderId: {
+      type: Number,
+      required: true
+    }
+  },
+  data() {
+    return {
+      photos: {}
+    }
+  },
+  async mounted() {
+    this.photos = await photoOrder.getPhotos(this.orderId)
+  },
+  methods: {
+    back() {
+      this.$emit('viewClose')
+    }
+  }
+}
+</script>
+
+<style scoped>
+.container {
+  padding: 0 30px;
+  .title {
+    height: 59px;
+    line-height: 59px;
+    color: $parent-title-color;
+    font-size: 16px;
+    font-weight: 500;
+    .back {
+      float: right;
+      margin-right: 40px;
+      cursor: pointer;
+    }
+  }
+  .img-list {
+    padding: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    .img-item {
+      margin-right: 20px;
+      margin-bottom: 20px;
+      .label {
+        margin-bottom: 10px;
+      }
+      .el-image {
+        max-width: 300px;
+      }
+    }
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- replace manual URL inputs with image uploaders in photo order list
- show view-only page for completed orders and hide actions for unpaid orders
- add conditional table actions and backend photos endpoint restriction

## Testing
- `npm run lint src/view/photo-order/photo-order-list.vue src/view/photo-order/photo-order-detail.vue src/model/photo-order.js src/component/base/table/lin-table.vue`
- `npm run test:unit`
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ef3cf6e88325ac08b2d359609cc2