### PR TITLE
feat: add configurable contact button ids

### DIFF
--- a/miniapp/zfb-uniapp/config.js
+++ b/miniapp/zfb-uniapp/config.js
@@ -1,0 +1,4 @@
+export default {
+  tntInstId: 'DEMO_TNT_INST_ID',
+  scene: 'DEMO_SCENE'
+}

--- a/miniapp/zfb-uniapp/pages/main/components/home-content.vue
+++ b/miniapp/zfb-uniapp/pages/main/components/home-content.vue
@@ -88,11 +88,13 @@
 
     <!-- 悬浮按钮 -->
     <view class="floating-button-wrapper">
-      <contact-button 
+      <contact-button
         class="floating-contact-button"
         size="46"
         color="#565DF4"
         icon="/static/customer-service.png"
+        :tnt-inst-id="contactConfig.tntInstId"
+        :scene="contactConfig.scene"
       >
       </contact-button>
     </view>
@@ -103,6 +105,7 @@
 import ScrollBanner from '@/components/scroll-banner.vue'
 import { getCertificates } from '@/utils/api.js'
 import mockCertificates from '@/mock/certificates.js'
+import contactConfig from '@/config.js'
 
 export default {
   name: 'HomeContent',
@@ -135,7 +138,8 @@ export default {
           src: '/static/banner/banner3.png',
           alt: '演示图片3'
         }
-      ]
+      ],
+      contactConfig
     }
   },
   computed: {

--- a/miniapp/zfb-uniapp/pages/main/components/order-content.vue
+++ b/miniapp/zfb-uniapp/pages/main/components/order-content.vue
@@ -103,11 +103,13 @@
                   <text class="btn-text">重新上传</text>
                 </view>
                 <view class="action-btn group-btn last consultation-wrapper">
-                  <contact-button 
+                  <contact-button
                     class="contact-button-native"
                     size="default"
                     color="#3d45e6"
                     icon="/static/customer-service.png"
+                    :tnt-inst-id="contactConfig.tntInstId"
+                    :scene="contactConfig.scene"
                   >
                   </contact-button>
                   <text class="btn-text">咨询客服</text>
@@ -116,11 +118,13 @@
               <view v-else class="action-buttons single">
                 <view class="consultation-wrapper-single">
                   <text class="btn-text">咨询客服</text>
-                  <contact-button 
+                  <contact-button
                     class="contact-button-native-single"
                     size="default"
                     color="#3d45e6"
                     icon="/static/customer-service.png"
+                    :tnt-inst-id="contactConfig.tntInstId"
+                    :scene="contactConfig.scene"
                   >
                   </contact-button>
                 </view>
@@ -135,6 +139,7 @@
 
 <script>
 import { getOrders } from '@/utils/api.js'
+import contactConfig from '@/config.js'
 export default {
   name: 'OrderContent',
   data() {
@@ -149,7 +154,8 @@ export default {
         { label: '已驳回', value: 'rejected' },
         { label: '已完成', value: 'completed' }
       ],
-      orders: []
+      orders: [],
+      contactConfig
     }
   },
   computed: {

--- a/miniapp/zfb-uniapp/pages/order-guide/order-guide.vue
+++ b/miniapp/zfb-uniapp/pages/order-guide/order-guide.vue
@@ -141,11 +141,13 @@
                     </view>
                     <view class="service-btn online-btn consultation-wrapper">
                         <text class="btn-text">在线咨询</text>
-                        <contact-button 
+                        <contact-button
                             class="contact-button-native"
                             size="default"
                             color="#1677ff"
                             icon="/static/customer-service.png"
+                            :tnt-inst-id="contactConfig.tntInstId"
+                            :scene="contactConfig.scene"
                         >
                         </contact-button>
                     </view>
@@ -156,11 +158,13 @@
 </template>
 
 <script>
+import contactConfig from '@/config.js'
 export default {
     name: 'OrderGuide',
     data() {
         return {
-            customerServicePhone: '18565104903' // 客服热线号码，请替换为实际号码
+            customerServicePhone: '18565104903', // 客服热线号码，请替换为实际号码
+            contactConfig
         }
     },
     methods: {


### PR DESCRIPTION
## Summary
- add global miniapp config for customer service contact
- bind contact button attributes to config values across pages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6232989ac832591305fb51de9b810