### PR TITLE
feat: support order remark

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/dto/CreatePhotoOrderDTO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/dto/CreatePhotoOrderDTO.java
@@ -23,5 +23,7 @@ public class CreatePhotoOrderDTO {
 
     @NotBlank
     private String certificateSnapshot;
+
+    private String remark;
 }
 

--- a/backend/src/main/java/io/github/talelin/latticy/model/PhotoOrderDO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/model/PhotoOrderDO.java
@@ -37,6 +37,8 @@ public class PhotoOrderDO {
 
     private String certificateSnapshot;
 
+    private String remark;
+
     private String rejectReason;
 
     private Integer status;

--- a/backend/update.sql
+++ b/backend/update.sql
@@ -32,6 +32,7 @@ CREATE TABLE photo_order (
   layout_photo VARCHAR(255),
   receipt_photo VARCHAR(255),
   certificate_snapshot TEXT,
+  remark VARCHAR(255),
   reject_reason VARCHAR(255),
   status TINYINT DEFAULT 0,
   create_time DATETIME,

--- a/cms-vue/src/view/photo-order/photo-order-detail.vue
+++ b/cms-vue/src/view/photo-order/photo-order-detail.vue
@@ -5,6 +5,7 @@
       <span class="back" @click="back"> <i class="iconfont icon-fanhui"></i> 返回 </span>
     </div>
     <el-divider></el-divider>
+    <div class="remark">备注：{{ remark || '无' }}</div>
     <div class="img-list">
       <div class="img-item" v-if="photos.standardPhoto">
         <div class="label">标准照</div>
@@ -30,6 +31,10 @@ export default {
     orderId: {
       type: Number,
       required: true
+    },
+    remark: {
+      type: String,
+      default: ''
     }
   },
   data() {
@@ -62,6 +67,9 @@ export default {
       margin-right: 40px;
       cursor: pointer;
     }
+  }
+  .remark {
+    margin: 10px 0;
   }
   .img-list {
     padding: 20px;

--- a/cms-vue/src/view/photo-order/photo-order-list.vue
+++ b/cms-vue/src/view/photo-order/photo-order-list.vue
@@ -37,7 +37,12 @@
       </span>
     </el-dialog>
   </div>
-  <photo-order-detail v-else :order-id="detailId" @viewClose="detailClose" />
+  <photo-order-detail
+    v-else
+    :order-id="detailId"
+    :remark="detailRemark"
+    @viewClose="detailClose"
+  />
 </template>
 
 <script>
@@ -54,6 +59,7 @@ export default {
         { prop: 'orderNo', label: '订单号' },
         { prop: 'documentName', label: '证照' },
         { prop: 'location', label: '地区' },
+        { prop: 'remark', label: '备注' },
         { prop: 'amount', label: '金额' },
         { prop: 'statusText', label: '状态' }
       ],
@@ -65,6 +71,7 @@ export default {
       previewPhoto: '',
       currentId: null,
       detailId: null,
+      detailRemark: '',
       showDetail: false,
       form: {
         standardPhoto: '',
@@ -133,6 +140,7 @@ export default {
     },
     handleView(val) {
       this.detailId = val.row.id
+      this.detailRemark = val.row.remark || ''
       this.showDetail = true
     },
     handlePhoto(val) {

--- a/miniapp/zfb-uniapp/pages/order-submit/order-submit.vue
+++ b/miniapp/zfb-uniapp/pages/order-submit/order-submit.vue
@@ -195,6 +195,7 @@ export default {
         const orderData = {
           document_name: this.documentInfo.name,
           location: this.selectedCity,
+          remark: this.orderRemark,
           amount: this.documentInfo.price,
           original_photo: photoUrl,
           certificate_snapshot: JSON.stringify(this.documentInfo)


### PR DESCRIPTION
## Summary
- submit order remarks from miniapp order page
- store and expose remark field in backend order APIs
- display order remarks in CMS photo order pages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6b4a3a8648325992bd4a74a694f29