### PR TITLE
feat: add async notification endpoint

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/common/enumeration/AsyncNotifyType.java
+++ b/backend/src/main/java/io/github/talelin/latticy/common/enumeration/AsyncNotifyType.java
@@ -1,0 +1,20 @@
+package io.github.talelin.latticy.common.enumeration;
+
+/**
+ * Common asynchronous notification types supported by the system.
+ * Currently placeholders without concrete processing.
+ */
+public enum AsyncNotifyType {
+    /** Alipay payment notifications */
+    ALIPAY,
+    /** WeChat Pay payment notifications */
+    WECHAT_PAY,
+    /** UnionPay payment notifications */
+    UNION_PAY,
+    /** SMS delivery reports */
+    SMS,
+    /** Email delivery events */
+    EMAIL,
+    /** Logistics status updates */
+    LOGISTICS
+}

--- a/backend/src/main/java/io/github/talelin/latticy/controller/v1/AsyncNotifyController.java
+++ b/backend/src/main/java/io/github/talelin/latticy/controller/v1/AsyncNotifyController.java
@@ -1,0 +1,40 @@
+package io.github.talelin.latticy.controller.v1;
+
+import io.github.talelin.latticy.common.enumeration.AsyncNotifyType;
+import io.github.talelin.latticy.vo.UnifyResponseVO;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Receive external asynchronous notification callbacks.
+ * <p>
+ * This endpoint is open and does not require authentication.
+ * It currently supports common notification types but does not process
+ * them yet. A unified success response is returned.
+ */
+@RestController
+@RequestMapping("/v1/notify")
+@Validated
+public class AsyncNotifyController {
+
+    @PostMapping("/{type}")
+    public UnifyResponseVO<String> receive(@PathVariable("type") AsyncNotifyType type,
+                                           @RequestBody(required = false) String body) {
+        // TODO: handle different notification types
+        switch (type) {
+            case ALIPAY:
+            case WECHAT_PAY:
+            case UNION_PAY:
+            case SMS:
+            case EMAIL:
+            case LOGISTICS:
+            default:
+                break;
+        }
+        return new UnifyResponseVO<>("ok");
+    }
+}


### PR DESCRIPTION
## Summary
- handle external async notification types with new controller
- document common async notification kinds

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.vintage.cms:backend:sleeve-0.3.0: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.2.5.RELEASE from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f4c9297c8325a8efb508ed82e334