### PR TITLE
feat: integrate content risk detection

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/common/configuration/AlipayProperties.java
+++ b/backend/src/main/java/io/github/talelin/latticy/common/configuration/AlipayProperties.java
@@ -18,5 +18,15 @@ public class AlipayProperties {
     private String gateway;
 
     private String notifyUrl;
+
+    /**
+     * Products for content risk detection
+     */
+    private String riskProducts;
+
+    /**
+     * Channel identifier for content risk detection
+     */
+    private String riskChannel;
 }
 

--- a/backend/src/main/java/io/github/talelin/latticy/controller/v1/ContentRiskController.java
+++ b/backend/src/main/java/io/github/talelin/latticy/controller/v1/ContentRiskController.java
@@ -1,0 +1,30 @@
+package io.github.talelin.latticy.controller.v1;
+
+import com.alipay.api.AlipayApiException;
+import io.github.talelin.latticy.dto.ContentDetectDTO;
+import io.github.talelin.latticy.service.ContentRiskService;
+import io.github.talelin.latticy.vo.UnifyResponseVO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/v1/mini/risk")
+@Validated
+public class ContentRiskController {
+
+    @Autowired
+    private ContentRiskService contentRiskService;
+
+    @PostMapping("/detect")
+    public UnifyResponseVO<Map<String, Boolean>> detect(@RequestBody @Validated ContentDetectDTO dto) throws AlipayApiException {
+        boolean pass = contentRiskService.detect(dto.getContentType(), dto.getData());
+        Map<String, Boolean> result = new HashMap<>();
+        result.put("pass", pass);
+        return new UnifyResponseVO<>(result);
+    }
+}
+

--- a/backend/src/main/java/io/github/talelin/latticy/dto/ContentDetectDTO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/dto/ContentDetectDTO.java
@@ -1,0 +1,21 @@
+package io.github.talelin.latticy.dto;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * DTO for content risk detection
+ */
+@Data
+public class ContentDetectDTO {
+
+    /** Content type: TEXT or PICTURE */
+    @NotBlank
+    private String contentType;
+
+    /** Content to be checked (text or image URL) */
+    @NotBlank
+    private String data;
+}
+

--- a/backend/src/main/java/io/github/talelin/latticy/service/ContentRiskService.java
+++ b/backend/src/main/java/io/github/talelin/latticy/service/ContentRiskService.java
@@ -1,0 +1,53 @@
+package io.github.talelin.latticy.service;
+
+import com.alipay.api.AlipayApiException;
+import com.alipay.api.AlipayClient;
+import com.alipay.api.DefaultAlipayClient;
+import com.alipay.api.domain.AlipaySecurityRiskContentSyncDetectModel;
+import com.alipay.api.request.AlipaySecurityRiskContentSyncDetectRequest;
+import com.alipay.api.response.AlipaySecurityRiskContentSyncDetectResponse;
+import io.github.talelin.latticy.common.configuration.AlipayProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.UUID;
+
+/**
+ * Service for invoking Alipay content risk detection API
+ */
+@Service
+public class ContentRiskService {
+
+    @Autowired
+    private AlipayProperties properties;
+
+    private AlipayClient buildClient() {
+        return new DefaultAlipayClient(
+                properties.getGateway(),
+                properties.getAppId(),
+                properties.getAppPrivateKey(),
+                "json",
+                "UTF-8",
+                properties.getAlipayPublicKey(),
+                "RSA2");
+    }
+
+    public boolean detect(String contentType, String data) throws AlipayApiException {
+        AlipayClient client = buildClient();
+        AlipaySecurityRiskContentSyncDetectRequest request = new AlipaySecurityRiskContentSyncDetectRequest();
+        AlipaySecurityRiskContentSyncDetectModel model = new AlipaySecurityRiskContentSyncDetectModel();
+        model.setRequestId(UUID.randomUUID().toString());
+        model.setProducts(properties.getRiskProducts());
+        model.setChannel(properties.getRiskChannel());
+        model.setContentType(contentType);
+        model.setDataList(Collections.singletonList(data));
+        request.setBizModel(model);
+        AlipaySecurityRiskContentSyncDetectResponse response = client.execute(request);
+        if (!response.isSuccess()) {
+            throw new AlipayApiException("content detect failed:" + response.getSubMsg());
+        }
+        return "pass".equalsIgnoreCase(response.getSuggestion());
+    }
+}
+

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -60,3 +60,5 @@ alipay:
   alipayPublicKey: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnaAG9QiKBgRZL3ysj+Zu5SqfDnUTWwAYeHN3sT5Jcg3d+b+RHlBByTxKeC1U3KiTsCVtdYRZ7Augxegxw48LFJNnCbDl6Egq8y70ZleDUi4JscUmk0sibQEuZ1EgkMQowNJaCPHZijQLRKMqjHTchMUiY7JB4JxC+xm+ShKOxGeJnlO4Cj/QDxhJNq6y4wXlUUObMr3/YM/KriAGQMi9t+giDHcqMu8IcvZkA/aIRk/j5AneHHA0rgtdnHryyDu/h6Q1onJxoy64tU6gav1EiWOL9adNK3r8LUiWF2c9g7vsywPghQ+H8pq1tVh7nk5wzHc0HqVVnFSVS7KgCxWQJwIDAQAB
   gateway: https://openapi.alipay.com/gateway.do
   notifyUrl: https://yihuizhi.com/v1/alipay/notify
+  riskProducts: TJ_POLITICS_MC,TJ_PORN_MC
+  riskChannel: tinyapp-eco-open

--- a/miniapp/zfb-uniapp/pages/photo-preview-choose/photo-preview-choose.vue
+++ b/miniapp/zfb-uniapp/pages/photo-preview-choose/photo-preview-choose.vue
@@ -55,7 +55,7 @@
 </template>
 
 <script>
-import { resubmitOrder, uploadImage } from '@/utils/api.js'
+import { resubmitOrder, uploadImage, detectContent } from '@/utils/api.js'
 
 export default {
   name: 'PhotoPreviewChoose',
@@ -197,11 +197,21 @@ export default {
         })
       }
       const next = url => {
-        if (this.orderId) {
-          doResubmit(url)
-        } else {
-          goCreate(url)
-        }
+        detectContent({ content_type: 'PICTURE', data: url })
+          .then(res => {
+            if (res.message.pass) {
+              if (this.orderId) {
+                doResubmit(url)
+              } else {
+                goCreate(url)
+              }
+            } else {
+              uni.showToast({ title: '您上传的图片不合规', icon: 'none' })
+            }
+          })
+          .catch(() => {
+            uni.showToast({ title: '检测失败', icon: 'none' })
+          })
       }
       if (this.imagePath.startsWith('https://resource/')) {
         uni.showLoading({ title: '上传中...' })

--- a/miniapp/zfb-uniapp/pages/photo-preview/photo-preview.vue
+++ b/miniapp/zfb-uniapp/pages/photo-preview/photo-preview.vue
@@ -55,7 +55,7 @@
 </template>
 
 <script>
-import { resubmitOrder, uploadImage } from '@/utils/api.js'
+import { resubmitOrder, uploadImage, detectContent } from '@/utils/api.js'
 
 export default {
   name: 'PhotoPreview',
@@ -179,11 +179,21 @@ export default {
         })
       }
       const next = url => {
-        if (this.orderId) {
-          doResubmit(url)
-        } else {
-          goCreate(url)
-        }
+        detectContent({ content_type: 'PICTURE', data: url })
+          .then(res => {
+            if (res.message.pass) {
+              if (this.orderId) {
+                doResubmit(url)
+              } else {
+                goCreate(url)
+              }
+            } else {
+              uni.showToast({ title: '您上传的图片不合规', icon: 'none' })
+            }
+          })
+          .catch(() => {
+            uni.showToast({ title: '检测失败', icon: 'none' })
+          })
       }
       if (this.imagePath.startsWith('https://resource/')) {
         uni.showLoading({ title: '上传中...' })

--- a/miniapp/zfb-uniapp/pages/search/search.vue
+++ b/miniapp/zfb-uniapp/pages/search/search.vue
@@ -85,7 +85,7 @@
 </template>
 
 <script>
-import { getCertificates } from '@/utils/api.js'
+import { getCertificates, detectContent } from '@/utils/api.js'
 import mockCertificates from '@/mock/certificates.js'
 export default {
     name: 'SearchPage',
@@ -122,6 +122,18 @@ export default {
 
             if (!keyword.trim()) {
                 this.searchResults = []
+                return
+            }
+
+            try {
+                const res = await detectContent({ content_type: 'TEXT', data: keyword })
+                if (!res.message.pass) {
+                    uni.showToast({ title: '您的输入不合规', icon: 'none' })
+                    this.searchResults = []
+                    return
+                }
+            } catch (e) {
+                uni.showToast({ title: '检测失败', icon: 'none' })
                 return
             }
 

--- a/miniapp/zfb-uniapp/utils/api.js
+++ b/miniapp/zfb-uniapp/utils/api.js
@@ -178,3 +178,4 @@ export function getOrderDetail(id) {
 export const alipayLogin = Post('/auth/alipay')
 export const refreshToken = () => refreshTokenRequest()
 export const alipayNotifyTest = Post('/../alipay/notify/test')
+export const detectContent = Post('/risk/detect')


### PR DESCRIPTION
## Summary
- add Alipay content risk detection service and endpoint
- run text and image risk checks in miniapp flows

## Testing
- `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68a6f808a4fc832581a93d2d45ae95ea