### PR TITLE
feat: implement heartbeat verification and token refresh

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/controller/v1/AuthController.java
+++ b/backend/src/main/java/io/github/talelin/latticy/controller/v1/AuthController.java
@@ -3,6 +3,7 @@ package io.github.talelin.latticy.controller.v1;
 import com.alipay.api.AlipayApiException;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import io.github.talelin.core.annotation.RefreshRequired;
+import io.github.talelin.core.annotation.LoginRequired;
 import io.github.talelin.core.token.DoubleJWT;
 import io.github.talelin.core.token.Tokens;
 import io.github.talelin.latticy.common.constant.IdentityConstant;
@@ -89,6 +90,16 @@ public class AuthController {
         res.put("code", 0);
         res.put("message", "ok");
         res.put("data", data);
+        return res;
+    }
+
+    @GetMapping("/heartbeat")
+    @LoginRequired
+    public Map<String, Object> heartbeat() {
+        Map<String, Object> res = new HashMap<>();
+        res.put("code", 0);
+        res.put("message", "ok");
+        res.put("data", new HashMap<>());
         return res;
     }
 }

--- a/miniapp/zfb-uniapp/utils/api.js
+++ b/miniapp/zfb-uniapp/utils/api.js
@@ -178,5 +178,6 @@ export function getOrderDetail(id) {
 
 export const alipayLogin = Post('/auth/alipay')
 export const refreshToken = () => refreshTokenRequest()
+export const heartbeat = Get('/auth/heartbeat')
 export const alipayNotifyTest = Post('/../alipay/notify/test')
 export const detectContent = Post('/risk/detect')


### PR DESCRIPTION
## Summary
- add `/v1/mini/auth/heartbeat` endpoint for authenticated liveness checks
- verify token validity in miniapp via heartbeat API with auto refresh

## Testing
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.2.5.RELEASE from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a804e94ce88325ab4d7d78c24e322f