### PR TITLE
feat: show certificate creation time

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/model/BaseModel.java
+++ b/backend/src/main/java/io/github/talelin/latticy/model/BaseModel.java
@@ -3,6 +3,7 @@ package io.github.talelin.latticy.model;
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 
@@ -16,7 +17,7 @@ public class BaseModel {
     @TableId(value = "id", type = IdType.AUTO)
     private Integer id;
 
-    @JsonIgnore
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
     private Date createTime;
 
     @JsonIgnore

--- a/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
+++ b/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
@@ -8,6 +8,7 @@ import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
 import java.util.List;
 
 @Service
@@ -20,6 +21,9 @@ public class CertificateServiceImpl implements CertificateService {
     public boolean create(CertificateDTO dto) {
         CertificateDO cert = new CertificateDO();
         copyFields(cert, dto);
+        Date now = new Date();
+        cert.setCreateTime(now);
+        cert.setUpdateTime(now);
         return certificateMapper.insert(cert) > 0;
     }
 

--- a/cms-vue/src/view/certificate/certificate-list.vue
+++ b/cms-vue/src/view/certificate/certificate-list.vue
@@ -18,6 +18,7 @@
 <script>
 import certificate from '@/model/certificate'
 import LinTable from '@/component/base/table/lin-table'
+import dayjs from 'dayjs'
 
 export default {
   components: {
@@ -34,6 +35,11 @@ export default {
         { prop: 'printSize', label: '打印尺寸' },
         { prop: 'pixelSize', label: '像素尺寸' },
         { prop: 'resolution', label: '分辨率' },
+        {
+          prop: 'createTime',
+          label: '创建时间',
+          formatter: (row) => dayjs(row.createTime).format('YYYY-MM-DD HH:mm:ss'),
+        },
       ],
       tableData: [],
       loading: false,


### PR DESCRIPTION
## Summary
- show certificate creation time in certificate list
- return creation timestamp from backend API

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM for com.vintage.cms:backend:sleeve-0.3.0)*
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68ac118e0e288325a3e2d4fad203e627