### PR TITLE
feat: add creation time to photo orders

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/model/BaseModel.java
+++ b/backend/src/main/java/io/github/talelin/latticy/model/BaseModel.java
@@ -3,6 +3,7 @@ package io.github.talelin.latticy.model;
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableLogic;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 
@@ -16,7 +17,7 @@ public class BaseModel {
     @TableId(value = "id", type = IdType.AUTO)
     private Integer id;
 
-    @JsonIgnore
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
     private Date createTime;
 
     @JsonIgnore

--- a/backend/src/main/java/io/github/talelin/latticy/model/PhotoOrderDO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/model/PhotoOrderDO.java
@@ -5,6 +5,8 @@ import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableLogic;
 import com.baomidou.mybatisplus.annotation.TableName;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 
 import java.math.BigDecimal;
@@ -47,12 +49,15 @@ public class PhotoOrderDO {
 
     private Integer status;
 
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "GMT+8")
     private Date createTime;
 
+    @JsonIgnore
     @TableField(update = "now()")
     private Date updateTime;
 
     @TableLogic
+    @JsonIgnore
     private Date deleteTime;
 }
 

--- a/backend/src/main/java/io/github/talelin/latticy/service/PhotoOrderService.java
+++ b/backend/src/main/java/io/github/talelin/latticy/service/PhotoOrderService.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +56,9 @@ public class PhotoOrderService extends ServiceImpl<PhotoOrderMapper, PhotoOrderD
         order.setOrderNo(String.valueOf(System.currentTimeMillis()));
         order.setStatus(PhotoOrderStatus.UNPAID.getValue());
         order.setUserId(LocalUser.getLocalUser().getId());
+        Date now = new Date();
+        order.setCreateTime(now);
+        order.setUpdateTime(now);
         this.save(order);
 
         // 从当前登录用户直接获取支付宝用户ID

--- a/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
+++ b/backend/src/main/java/io/github/talelin/latticy/service/impl/CertificateServiceImpl.java
@@ -8,6 +8,7 @@ import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
 import java.util.List;
 
 @Service
@@ -20,6 +21,9 @@ public class CertificateServiceImpl implements CertificateService {
     public boolean create(CertificateDTO dto) {
         CertificateDO cert = new CertificateDO();
         copyFields(cert, dto);
+        Date now = new Date();
+        cert.setCreateTime(now);
+        cert.setUpdateTime(now);
         return certificateMapper.insert(cert) > 0;
     }
 

--- a/cms-vue/src/view/certificate/certificate-list.vue
+++ b/cms-vue/src/view/certificate/certificate-list.vue
@@ -18,6 +18,7 @@
 <script>
 import certificate from '@/model/certificate'
 import LinTable from '@/component/base/table/lin-table'
+import dayjs from 'dayjs'
 
 export default {
   components: {
@@ -26,6 +27,11 @@ export default {
   data() {
     return {
       tableColumn: [
+        {
+          prop: 'createTime',
+          label: '创建时间',
+          formatter: (row) => dayjs(row.createTime).format('YYYY-MM-DD HH:mm:ss'),
+        },
         { prop: 'name', label: '名称' },
         { prop: 'category', label: '分类' },
         { prop: 'hasReceipt', label: '含回执' },

--- a/cms-vue/src/view/photo-order/photo-order-list.vue
+++ b/cms-vue/src/view/photo-order/photo-order-list.vue
@@ -50,12 +50,18 @@ import LinTable from '@/component/base/table/lin-table'
 import UploadImgs from '@/component/base/upload-image'
 import photoOrder from '@/model/photo-order'
 import PhotoOrderDetail from './photo-order-detail'
+import dayjs from 'dayjs'
 
 export default {
   components: { LinTable, UploadImgs, PhotoOrderDetail },
   data() {
     return {
       tableColumn: [
+        {
+          prop: 'createTime',
+          label: '创建时间',
+          formatter: row => dayjs(row.createTime).format('YYYY-MM-DD HH:mm:ss')
+        },
         { prop: 'orderNo', label: '订单号' },
         { prop: 'documentName', label: '证照' },
         { prop: 'location', label: '地区' },


### PR DESCRIPTION
## Summary
- show creation timestamps on certificate and photo order lists
- include formatted creation time in photo order API responses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68ac118e0e288325a3e2d4fad203e627