### PR TITLE
fix: align resubmit field naming

### DIFF
--- a/miniapp/zfb-uniapp/pages/custom-camera/custom-camera.vue
+++ b/miniapp/zfb-uniapp/pages/custom-camera/custom-camera.vue
@@ -258,7 +258,7 @@ export default {
       if (!this.capturedImage) return
       const handle = url => {
         if (this.orderId) {
-          resubmitOrder(this.orderId, { originalPhoto: url })
+          resubmitOrder(this.orderId, { original_photo: url })
             .then(() => {
               uni.hideLoading()
               uni.showToast({ title: '上传成功', icon: 'success' })


### PR DESCRIPTION
## Summary
- ensure custom camera uses `original_photo` when resubmitting an order

## Testing
- `cd miniapp/zfb-uniapp && npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b256b5961c8325b2902918fadfd617