### PR TITLE
feat: support photo order require type

### DIFF
--- a/backend/src/main/java/io/github/talelin/latticy/dto/CreatePhotoOrderDTO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/dto/CreatePhotoOrderDTO.java
@@ -24,6 +24,8 @@ public class CreatePhotoOrderDTO {
     @NotBlank
     private String certificateSnapshot;
 
+    private Integer requireType;
+
     private String cardNo;
 
     private String remark;

--- a/backend/src/main/java/io/github/talelin/latticy/model/PhotoOrderDO.java
+++ b/backend/src/main/java/io/github/talelin/latticy/model/PhotoOrderDO.java
@@ -43,6 +43,8 @@ public class PhotoOrderDO {
 
     private String certificateSnapshot;
 
+    private Integer requireType;
+
     private String remark;
 
     private String rejectReason;

--- a/backend/update.sql
+++ b/backend/update.sql
@@ -35,6 +35,7 @@ CREATE TABLE photo_order (
   layout_photo VARCHAR(255),
   receipt_photo VARCHAR(255),
   certificate_snapshot TEXT,
+  require_type TINYINT,
   remark VARCHAR(255),
   reject_reason VARCHAR(255),
   status TINYINT DEFAULT 0,

--- a/cms-vue/src/view/photo-order/photo-order-list.vue
+++ b/cms-vue/src/view/photo-order/photo-order-list.vue
@@ -66,6 +66,14 @@ export default {
         { prop: 'documentName', label: '证照' },
         { prop: 'location', label: '地区' },
         { prop: 'cardNo', label: '身份证号' },
+        {
+          prop: 'requireType',
+          label: '照片类型',
+          formatter: row => {
+            const map = { 0: '电子照', 1: '冲印照' }
+            return row.requireType === 0 || row.requireType === 1 ? map[row.requireType] : ''
+          }
+        },
         { prop: 'remark', label: '备注' },
         { prop: 'amount', label: '金额' },
         { prop: 'statusText', label: '状态' }


### PR DESCRIPTION
## Summary
- add `require_type` field to photo order entities and schema
- display photo type column in CMS order list

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68bbd9fda5988325b18f0aa8d5c7af66